### PR TITLE
Resolve errors issued by Pyright

### DIFF
--- a/gradia/clipboard.py
+++ b/gradia/clipboard.py
@@ -33,7 +33,12 @@ def copy_file_to_clipboard(local_path: str) -> None:
     with open(local_path, "rb") as f:
         png_data: bytes = f.read()
 
+    display = Gdk.Display.get_default()
+    if not display:
+        print("Warning: Failed to retrieve `Gdk.Display` object.")
+        return
+
     bytes_data: GLib.Bytes = GLib.Bytes.new(png_data)
-    clipboard: Gdk.Clipboard = Gdk.Display.get_default().get_clipboard()
+    clipboard: Gdk.Clipboard = display.get_clipboard()
     content_provider: Gdk.ContentProvider = Gdk.ContentProvider.new_for_bytes("image/png", bytes_data)
     clipboard.set_content(content_provider)

--- a/gradia/main.py
+++ b/gradia/main.py
@@ -39,7 +39,7 @@ class GradiaApp(Adw.Application):
         self.file_to_open = None
 
     def do_activate(self):
-        self.ui = GradientWindow(self, self.temp_dir, version=self.version)
+        self.ui = GradientWindow(self.temp_dir, version=self.version, application=self)
         self.ui.build_ui()
         self.ui.show()
 

--- a/gradia/main.py
+++ b/gradia/main.py
@@ -18,12 +18,18 @@ import sys
 import os
 import tempfile
 import shutil
+
+from typing import Sequence
+
 from gi.repository import Adw, Gio
+
 from gradia.ui.window import GradientWindow
 
 
 class GradiaApp(Adw.Application):
-    def __init__(self, version=None):
+    __gtype_name__ = "GradiaApp"
+
+    def __init__(self, version: str):
         super().__init__(
             application_id="be.alexandervanhee.gradia",
             flags=Gio.ApplicationFlags.HANDLES_OPEN
@@ -37,7 +43,7 @@ class GradiaApp(Adw.Application):
         self.ui.build_ui()
         self.ui.show()
 
-    def do_open(self, files, n_files, hint):
+    def do_open(self, files: Sequence[Gio.File], hint: str):
         self.activate()
 
     def do_shutdown(self):
@@ -50,7 +56,7 @@ class GradiaApp(Adw.Application):
             Gio.Application.do_shutdown(self)
 
 
-def main(version=None):
+def main(version: str):
     try:
         app = GradiaApp(version=version)
         return app.run(sys.argv)

--- a/gradia/ui/image_exporters.py
+++ b/gradia/ui/image_exporters.py
@@ -60,7 +60,7 @@ class FileDialogExporter(BaseImageExporter):
             filters.append(file_filter)
 
         save_dialog.set_filters(filters)
-        save_dialog.save(self.window.win, None, self._on_save_finished)
+        save_dialog.save(self.window, None, self._on_save_finished)
 
     def _on_save_finished(self, dialog: Gtk.FileDialog, result: Gio.AsyncResult) -> None:
         """Handle save dialog completion"""

--- a/gradia/ui/image_exporters.py
+++ b/gradia/ui/image_exporters.py
@@ -62,7 +62,7 @@ class FileDialogExporter(BaseImageExporter):
         save_dialog.set_filters(filters)
         save_dialog.save(self.window.win, None, self._on_save_finished)
 
-    def _on_save_finished(self, dialog: Gtk.FileDialog, result: Gio.Cancellable) -> None:
+    def _on_save_finished(self, dialog: Gtk.FileDialog, result: Gio.AsyncResult) -> None:
         """Handle save dialog completion"""
         try:
             file = dialog.save_finish(result)

--- a/gradia/ui/image_loaders.py
+++ b/gradia/ui/image_loaders.py
@@ -62,7 +62,7 @@ class FileDialogImageLoader(BaseImageLoader):
         file_dialog.set_title(_("Open Image"))
 
         image_filter = Gtk.FileFilter()
-        image_filter.set_name("Image Files")
+        image_filter.set_name(_("Image Files"))
         for _ext, mime_type in self.SUPPORTED_INPUT_FORMATS:
             image_filter.add_mime_type(mime_type)
 
@@ -72,7 +72,7 @@ class FileDialogImageLoader(BaseImageLoader):
 
         file_dialog.open(self.window.win, None, self._on_file_selected)
 
-    def _on_file_selected(self, dialog: Gtk.FileDialog, result: Gio.Cancellable) -> None:
+    def _on_file_selected(self, dialog: Gtk.FileDialog, result: Gio.AsyncResult) -> None:
         """Handle file selection from dialog"""
         try:
             file = dialog.open_finish(result)
@@ -138,7 +138,7 @@ class ClipboardImageLoader(BaseImageLoader):
 
     def load_from_clipboard(self) -> None:
         """Load image from system clipboard"""
-        clipboard = Gdk.Display.get_default().get_clipboard()
+        clipboard = self.window.get_clipboard()
         clipboard.read_texture_async(None, self._handle_clipboard_texture)
 
     def _handle_clipboard_texture(

--- a/gradia/ui/image_loaders.py
+++ b/gradia/ui/image_loaders.py
@@ -70,7 +70,7 @@ class FileDialogImageLoader(BaseImageLoader):
         filters.append(image_filter)
         file_dialog.set_filters(filters)
 
-        file_dialog.open(self.window.win, None, self._on_file_selected)
+        file_dialog.open(self.window, None, self._on_file_selected)
 
     def _on_file_selected(self, dialog: Gtk.FileDialog, result: Gio.AsyncResult) -> None:
         """Handle file selection from dialog"""

--- a/gradia/ui/window.py
+++ b/gradia/ui/window.py
@@ -46,10 +46,10 @@ class GradientWindow(Adw.ApplicationWindow):
     # Temp file names
     TEMP_PROCESSED_FILENAME: str = "processed.png"
 
-    def __init__(self, app: Adw.Application, temp_dir: str, version: str, **kwargs) -> None:
+    def __init__(self, temp_dir: str, version: str, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self.app: Adw.Application = app
+        self.app: Adw.Application = kwargs['application']
         self.temp_dir: str = temp_dir
         self.version: str = version
         self.image_path: Optional[str] = None
@@ -85,7 +85,7 @@ class GradientWindow(Adw.ApplicationWindow):
         self.create_action("save", lambda *_: self.export_manager.save_to_file(), ["<Primary>s"], enabled=False)
         self.create_action("copy", lambda *_: self.export_manager.copy_to_clipboard(), ["<Primary>c"], enabled=False)
 
-        self.create_action("quit", lambda *_: self.win.close(), ["<Primary>q"])
+        self.create_action("quit", lambda *_: self.close(), ["<Primary>q"])
 
     def create_action(self, name: str, callback: Callable[..., None], shortcuts: Optional[list[str]] = None, enabled: bool = True) -> None:
         action: Gio.SimpleAction = Gio.SimpleAction.new(name, None)
@@ -113,11 +113,10 @@ class GradientWindow(Adw.ApplicationWindow):
         self._setup_main_layout()
 
     def _setup_window(self) -> None:
-        self.win: Adw.ApplicationWindow = Adw.ApplicationWindow(application=self.app)
-        self.win.set_title("Gradia")
-        self.win.set_default_size(self.DEFAULT_WINDOW_WIDTH, self.DEFAULT_WINDOW_HEIGHT)
+        self.set_title("Gradia")
+        self.set_default_size(self.DEFAULT_WINDOW_WIDTH, self.DEFAULT_WINDOW_HEIGHT)
         self.toast_overlay: Adw.ToastOverlay = Adw.ToastOverlay()
-        self.win.set_content(self.toast_overlay)
+        self.set_content(self.toast_overlay)
 
     def _setup_toolbar(self) -> None:
         self.toolbar_view: Adw.ToolbarView = Adw.ToolbarView()
@@ -162,11 +161,11 @@ class GradientWindow(Adw.ApplicationWindow):
         self.toolbar_view.set_content(self.main_box)
         self.toast_overlay.set_child(self.toolbar_view)
 
-        self.win.connect("notify::default-width", self._on_window_resize)
-        self.win.connect("notify::default-height", self._on_window_resize)
+        self.connect("notify::default-width", self._on_window_resize)
+        self.connect("notify::default-height", self._on_window_resize)
 
     def _on_window_resize(self, *args: Any) -> None:
-        width: int = self.win.get_width()
+        width: int = self.get_width()
         if width < 800:
             self.main_box.set_orientation(Gtk.Orientation.VERTICAL)
             self.sidebar.set_size_request(-1, 200)
@@ -175,7 +174,7 @@ class GradientWindow(Adw.ApplicationWindow):
             self.sidebar.set_size_request(300, -1)
 
     def show(self) -> None:
-        self.win.present()
+        self.present()
 
     def _start_processing(self) -> None:
         self.toolbar_view.set_top_bar_style(Adw.ToolbarStyle.RAISED)
@@ -295,7 +294,7 @@ class GradientWindow(Adw.ApplicationWindow):
 
     def _on_about_activated(self, action: Gio.SimpleAction, param) -> None:
         about = create_about_dialog(version=self.version)
-        about.present(self.win)
+        about.present(self)
 
     def _set_save_and_toggle_(self, enabled: bool) -> None:
         for action_name in ["save", "copy"]:
@@ -304,7 +303,7 @@ class GradientWindow(Adw.ApplicationWindow):
                 action.set_enabled(enabled)
 
     def _on_shortcuts_activated(self, action: Gio.SimpleAction, param) -> None:
-        shortcuts = create_shortcuts_dialog(self.win)
+        shortcuts = create_shortcuts_dialog(self)
         shortcuts.connect("close-request", self._on_shortcuts_closed)
         shortcuts.present()
 

--- a/gradia/ui/window.py
+++ b/gradia/ui/window.py
@@ -30,7 +30,9 @@ from gradia.ui.image_loaders import ImportManager
 from gradia.ui.image_exporters import ExportManager
 
 
-class GradientWindow:
+class GradientWindow(Adw.ApplicationWindow):
+    __gtype_name__ = 'GradientWindow'
+
     DEFAULT_WINDOW_WIDTH: int = 900
     DEFAULT_WINDOW_HEIGHT: int = 600
     DEFAULT_PANED_POSITION: int = 650
@@ -44,7 +46,9 @@ class GradientWindow:
     # Temp file names
     TEMP_PROCESSED_FILENAME: str = "processed.png"
 
-    def __init__(self, app: Adw.Application, temp_dir: str, version: str) -> None:
+    def __init__(self, app: Adw.Application, temp_dir: str, version: str, **kwargs) -> None:
+        super().__init__(**kwargs)
+
         self.app: Adw.Application = app
         self.temp_dir: str = temp_dir
         self.version: str = version
@@ -294,9 +298,8 @@ class GradientWindow:
         about.present(self.win)
 
     def _set_save_and_toggle_(self, enabled: bool) -> None:
-        app = self.app
         for action_name in ["save", "copy"]:
-            action: Optional[Gio.SimpleAction] = app.lookup_action(action_name)
+            action: Optional[Gio.SimpleAction] = self.app.lookup_action(action_name)
             if action:
                 action.set_enabled(enabled)
 


### PR DESCRIPTION
This also makes the `GradientWindow` class a `Adw.ApplicationWindow` inheritor, which makes code more straightforward by removing `self.win` object.

### Changes:
- add `__gtype_name__` to GradiaApp and GradientWindow
- Inherit from `Adw.ApplicationWindow` in GradientWindow
- make `version` parameter required in `main` module
- make image filter name string in `FileDialogImageLoader` translatable