### PR TITLE
Improve Initial View by Displaying a Grid of Recent Screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,4 @@ pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/meson,flatpak,python,visualstudiocode
 /.flatpak
+/.vscode

--- a/be.alexandervanhee.gradia.json
+++ b/be.alexandervanhee.gradia.json
@@ -8,7 +8,8 @@
     "--share=ipc",
     "--socket=fallback-x11",
     "--device=dri",
-    "--socket=wayland"
+    "--socket=wayland",
+    "--filesystem=xdg-pictures/Screenshots"
   ],
   "cleanup": [
     "/include",

--- a/gradia/constants.py
+++ b/gradia/constants.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2025 Alexander Vanhee
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+GradientPreset = tuple[str, str, int]
+PREDEFINED_GRADIENTS: list[GradientPreset] = [
+    ("#36d1dc", "#5b86e5", 90),
+    ("#ff5f6d", "#ffc371", 45),
+    ("#453383", "#5494e8", 0),
+    ("#00c6ff", "#0072ff", 180),
+    ("#8ff0a4", "#2ec27e", 135),
+    ("#f6f5f4", "#5e5c64", 135),
+]

--- a/gradia/graphics/gradient.py
+++ b/gradia/graphics/gradient.py
@@ -21,6 +21,7 @@ from collections.abc import Callable
 from typing import Optional
 from PIL import Image
 from gi.repository import Gtk, Gdk, Adw
+from gradia.constants import PREDEFINED_GRADIENTS
 
 
 HexColor = str
@@ -120,14 +121,6 @@ class GradientBackground:
 
 
 class GradientSelector:
-    PREDEFINED_GRADIENTS: list[GradientPreset] = [
-        ("#36d1dc", "#5b86e5", 90),
-        ("#ff5f6d", "#ffc371", 45),
-        ("#453383", "#5494e8", 0),
-        ("#00c6ff", "#0072ff", 180),
-        ("#8ff0a4", "#2ec27e", 135),
-        ("#f6f5f4", "#5e5c64", 135),
-    ]
 
     def __init__(
         self, 
@@ -250,7 +243,7 @@ class GradientSelector:
             homogeneous=True
         )
 
-        for i, (start, end, angle) in enumerate(self.PREDEFINED_GRADIENTS):
+        for i, (start, end, angle) in enumerate(PREDEFINED_GRADIENTS):
             gradient_name = f"gradient-preview-{i}"
 
             css = f"""

--- a/gradia/meson.build
+++ b/gradia/meson.build
@@ -39,7 +39,8 @@ configure_file(
 gradia_sources = [
   '__init__.py',
   'main.py',
-  'clipboard.py'
+  'clipboard.py',
+  'constants.py'
 ]
 
 install_data(gradia_sources, install_dir: moduledir)

--- a/gradia/ui/recent_picker.py
+++ b/gradia/ui/recent_picker.py
@@ -100,9 +100,7 @@ class RecentPicker(Gtk.Box):
     GRID_ROWS = 2
     GRID_COLS = 3
     GRID_ROW_SPACING = 10
-    GRID_COL_SPACING = 10
-    FRAME_WIDTH = 210
-    FRAME_HEIGHT = 110
+    GRID_COL_SPACING = 30
     FRAME_SPACING = 5
     IMAGE_WIDTH = 210
     IMAGE_HEIGHT = 120
@@ -136,12 +134,12 @@ class RecentPicker(Gtk.Box):
                 index = row * self.GRID_COLS + col
 
                 container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=self.FRAME_SPACING)
-                container.set_size_request(self.FRAME_WIDTH, self.FRAME_HEIGHT)
+                container.set_size_request(self.IMAGE_WIDTH, self.IMAGE_HEIGHT)
 
                 frame = Gtk.Frame()
                 frame.set_size_request(self.IMAGE_WIDTH, self.IMAGE_HEIGHT)
 
-                img_button = Gtk.Button()
+                img_button = Gtk.Button(has_frame=False)
                 img_button.set_size_request(self.IMAGE_WIDTH, self.IMAGE_HEIGHT)
                 img_button.add_css_class("card")
                 img_button.connect("clicked", lambda btn, idx=index: self.on_image_click(idx))
@@ -249,9 +247,9 @@ class RecentPicker(Gtk.Box):
                     self.name_labels[i].set_text(file_obj.name)
                     print(f"Error loading image {file_obj.path}: {e}")
             else:
-                empty_label = Gtk.Label(label="No image")
-                empty_label.add_css_class("dim-label")
-                self.image_buttons[i].set_child(empty_label)
+                icon = Gtk.Image.new_from_icon_name("image-missing-symbolic")
+                icon.set_pixel_size(64)
+                self.image_buttons[i].set_child(icon)
                 self.image_buttons[i].set_sensitive(False)
                 self.name_labels[i].set_text("")
 

--- a/gradia/ui/recent_picker.py
+++ b/gradia/ui/recent_picker.py
@@ -146,9 +146,8 @@ class RecentPicker(Gtk.Box):
 
                 self._apply_gradient_to_button(img_button, index)
 
-                spinner = Adw.Spinner.new()
-                spinner.set_size_request(24, 24)
-                img_button.set_child(spinner)
+                placeholder = Gtk.Box()
+                img_button.set_child(placeholder)
 
                 frame.set_child(img_button)
                 self.image_buttons.append(img_button)
@@ -200,6 +199,19 @@ class RecentPicker(Gtk.Box):
             Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         )
 
+    def _fade_in_widget(self, widget):
+        widget.set_opacity(0.0)
+        target = Adw.PropertyAnimationTarget.new(widget, "opacity")
+        animation = Adw.TimedAnimation(
+            widget=widget,
+            value_from=0.0,
+            value_to=1.0,
+            duration=300,
+            easing=Adw.Easing.EASE_OUT,
+            target=target,
+        )
+        animation.play()
+
     def load_images(self):
         def load_in_thread():
             recent_files = self.image_getter.get_recent_screenshot_files()
@@ -234,6 +246,7 @@ class RecentPicker(Gtk.Box):
 
                     image = Gtk.Image.new_from_pixbuf(scaled_pixbuf)
                     self.image_buttons[i].set_child(image)
+                    self._fade_in_widget(image)
 
                     self.name_labels[i].set_text(file_obj.name)
 
@@ -244,6 +257,8 @@ class RecentPicker(Gtk.Box):
 
                     error_label = Gtk.Label(label=filename)
                     self.image_buttons[i].set_child(error_label)
+                    self._fade_in_widget(error_label)
+
                     self.name_labels[i].set_text(file_obj.name)
                     print(f"Error loading image {file_obj.path}: {e}")
             else:

--- a/gradia/ui/recent_picker.py
+++ b/gradia/ui/recent_picker.py
@@ -1,0 +1,265 @@
+# Copyright (C) 2025 Alexander Vanhee
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import gi
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+from gi.repository import Gtk, Adw, GdkPixbuf, Gio, GLib, Gdk
+from gradia.constants import PREDEFINED_GRADIENTS
+from pathlib import Path
+import time
+import re
+import threading
+import random
+import gettext
+
+ngettext = gettext.ngettext
+
+class RecentFile:
+    def __init__(self, path: Path):
+        self.path = path
+        self.folder = str(path.parent)
+        self.name = self._get_friendly_name(path)
+
+    def _get_friendly_name(self, path: Path) -> str:
+        modified_time = path.stat().st_mtime
+        return self._time_ago(modified_time)
+
+    def _time_ago(self, past_timestamp: float) -> str:
+        now = time.time()
+        diff = int(now - past_timestamp)
+
+        if diff < 60:
+            return ngettext("%d second ago", "%d seconds ago", diff) % diff
+        elif diff < 3600:
+            minutes = diff // 60
+            return ngettext("%d minute ago", "%d minutes ago", minutes) % minutes
+        elif diff < 86400:
+            hours = diff // 3600
+            return ngettext("%d hour ago", "%d hours ago", hours) % hours
+        else:
+            days = diff // 86400
+            return ngettext("%d day ago", "%d days ago", days) % days
+
+class RecentImageGetter:
+    MAX_RESULTS = 6
+    XDG_USER_DIRS_FILE = Path.home() / ".config" / "user-dirs.dirs"
+    FALLBACK_PICTURES_PATH = Path.home() / "Pictures"
+    SCREENSHOTS_SUBDIR_NAME = "Screenshots"
+
+    def __init__(self):
+        pass
+
+    def get_recent_screenshot_files(self) -> list:
+        """Returns a list of RecentFile object with the 6 most recent screenshots"""
+        screenshots_dir = self._get_screenshots_directory()
+        if not screenshots_dir.exists():
+            print("Screenshots directory does not exist.")
+            return []
+
+        image_extensions = {'.png', '.jpg', '.jpeg', '.webp', '.avif'}
+        all_files = [f for f in screenshots_dir.iterdir()
+                    if f.is_file() and f.suffix.lower() in image_extensions]
+
+        sorted_files = sorted(all_files, key=lambda f: f.stat().st_mtime, reverse=True)
+        top_files = sorted_files[:self.MAX_RESULTS]
+        return [RecentFile(f) for f in top_files]
+
+    def _get_screenshots_directory(self) -> Path:
+        pictures_dir = self._get_xdg_user_dir("XDG_PICTURES_DIR") or self.FALLBACK_PICTURES_PATH
+        return pictures_dir / self.SCREENSHOTS_SUBDIR_NAME
+
+    def _get_xdg_user_dir(self, key: str) -> Path | None:
+        if not self.XDG_USER_DIRS_FILE.exists():
+            return None
+
+        pattern = re.compile(rf'{key}="([^"]+)"')
+        with open(self.XDG_USER_DIRS_FILE, "r") as f:
+            for line in f:
+                match = pattern.match(line.strip())
+                if match:
+                    path = match.group(1).replace("$HOME", str(Path.home()))
+                    return Path(path)
+        return None
+
+class RecentPicker(Gtk.Box):
+    GRID_ROWS = 2
+    GRID_COLS = 3
+    GRID_ROW_SPACING = 10
+    GRID_COL_SPACING = 10
+    FRAME_WIDTH = 210
+    FRAME_HEIGHT = 110
+    FRAME_SPACING = 5
+    IMAGE_WIDTH = 210
+    IMAGE_HEIGHT = 120
+    MAX_WIDTH_CHARS = 20
+    MAX_FILENAME_LENGTH = 30
+    FILENAME_TRUNCATE_LENGTH = 27
+
+    def __init__(self, callback=None):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
+        self.image_getter = RecentImageGetter()
+        self.callback = callback
+        self.image_buttons = []
+        self.name_labels = []
+        self.recent_files = []
+
+        self.gradient_colors = PREDEFINED_GRADIENTS
+
+        random.shuffle(self.gradient_colors)
+
+        self.create_widgets()
+        self.load_images()
+
+    def create_widgets(self):
+        grid = Gtk.Grid()
+        grid.set_row_spacing(self.GRID_ROW_SPACING)
+        grid.set_column_spacing(self.GRID_COL_SPACING)
+        grid.set_halign(Gtk.Align.CENTER)
+
+        for row in range(self.GRID_ROWS):
+            for col in range(self.GRID_COLS):
+                index = row * self.GRID_COLS + col
+
+                container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=self.FRAME_SPACING)
+                container.set_size_request(self.FRAME_WIDTH, self.FRAME_HEIGHT)
+
+                frame = Gtk.Frame()
+                frame.set_size_request(self.IMAGE_WIDTH, self.IMAGE_HEIGHT)
+
+                img_button = Gtk.Button()
+                img_button.set_size_request(self.IMAGE_WIDTH, self.IMAGE_HEIGHT)
+                img_button.add_css_class("card")
+                img_button.connect("clicked", lambda btn, idx=index: self.on_image_click(idx))
+
+                self._apply_gradient_to_button(img_button, index)
+
+                spinner = Adw.Spinner.new()
+                spinner.set_size_request(24, 24)
+                img_button.set_child(spinner)
+
+                frame.set_child(img_button)
+                self.image_buttons.append(img_button)
+                container.append(frame)
+
+                name_label = Gtk.Label()
+                name_label.set_wrap(True)
+                name_label.set_max_width_chars(self.MAX_WIDTH_CHARS)
+                name_label.add_css_class("caption")
+                name_label.set_halign(Gtk.Align.CENTER)
+                self.name_labels.append(name_label)
+                container.append(name_label)
+
+                grid.attach(container, col, row, 1, 1)
+
+        self.append(grid)
+
+    def _apply_gradient_to_button(self, button, index):
+        gradient_name = f"gradient-button-{index}"
+        button.set_name(gradient_name)
+
+        color_index = index % len(self.gradient_colors)
+        start_color, end_color, angle = self.gradient_colors[color_index]
+
+        css = f"""
+            button#{gradient_name} {{
+                background-image: linear-gradient({angle}deg, {start_color}, {end_color});
+                min-width: {self.IMAGE_WIDTH}px;
+                min-height: {self.IMAGE_HEIGHT}px;
+                background-size: cover;
+                transition: filter 0.3s ease;
+            }}
+            button#{gradient_name}:hover {{
+                filter: brightness(1.2);
+            }}
+            button#{gradient_name}:active {{
+                filter: brightness(0.9);
+            }}
+            button#{gradient_name} image {{
+                border-radius: 4px;
+            }}
+        """
+
+        css_provider = Gtk.CssProvider()
+        css_provider.load_from_string(css)
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            css_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+
+    def load_images(self):
+        def load_in_thread():
+            recent_files = self.image_getter.get_recent_screenshot_files()
+            GLib.idle_add(self._update_display, recent_files)
+
+        thread = threading.Thread(target=load_in_thread, daemon=True)
+        thread.start()
+
+    def _update_display(self, recent_files):
+        self.recent_files = recent_files
+
+        for i in range(self.GRID_ROWS * self.GRID_COLS):
+            if i < len(recent_files):
+                file_obj = recent_files[i]
+
+                try:
+                    pixbuf = GdkPixbuf.Pixbuf.new_from_file(str(file_obj.path))
+
+                    width = pixbuf.get_width()
+                    height = pixbuf.get_height()
+
+                    scale_x = self.IMAGE_WIDTH / width
+                    scale_y = self.IMAGE_HEIGHT / height
+                    scale = min(scale_x, scale_y)
+
+                    new_width = int(width * scale)
+                    new_height = int(height * scale)
+
+                    scaled_pixbuf = pixbuf.scale_simple(
+                        new_width, new_height, GdkPixbuf.InterpType.BILINEAR
+                    )
+
+                    image = Gtk.Image.new_from_pixbuf(scaled_pixbuf)
+                    self.image_buttons[i].set_child(image)
+
+                    self.name_labels[i].set_text(file_obj.name)
+
+                except Exception as e:
+                    filename = file_obj.path.name
+                    if len(filename) > self.MAX_FILENAME_LENGTH:
+                        filename = filename[:self.FILENAME_TRUNCATE_LENGTH] + "..."
+
+                    error_label = Gtk.Label(label=filename)
+                    self.image_buttons[i].set_child(error_label)
+                    self.name_labels[i].set_text(file_obj.name)
+                    print(f"Error loading image {file_obj.path}: {e}")
+            else:
+                empty_label = Gtk.Label(label="No image")
+                empty_label.add_css_class("dim-label")
+                self.image_buttons[i].set_child(empty_label)
+                self.image_buttons[i].set_sensitive(False)
+                self.name_labels[i].set_text("")
+
+    def on_image_click(self, index):
+        if index < len(self.recent_files):
+            file_path = self.recent_files[index].path
+            if self.callback:
+                self.callback(str(file_path))
+
+    def refresh(self):
+        self.load_images()

--- a/gradia/ui/ui_parts.py
+++ b/gradia/ui/ui_parts.py
@@ -21,6 +21,7 @@ from gi.repository import Gtk, Gio, Adw, Gdk, GLib
 
 from gradia.overlay.drawing_actions import DrawingMode
 from gradia.overlay.drawing_overlay import DrawingOverlay
+from gradia.ui.recent_picker import RecentPicker
 
 def create_header_bar() -> Adw.HeaderBar:
     header_bar = Adw.HeaderBar()
@@ -175,25 +176,28 @@ def create_spinner_widget() -> tuple[Gtk.Box, Adw.Spinner]:
     return spinner_box, spinner
 
 def create_status_page() -> Adw.StatusPage:
+    def on_recent_image_click(path: str):
+            app = Gio.Application.get_default()
+            action = app.lookup_action("open-path")
+            if action:
+                param = GLib.Variant("s", path)
+                action.activate(param)
+
+    picker = RecentPicker(callback=on_recent_image_click)
+
     screenshot_btn = Gtk.Button.new_with_label(_("_Take a screenshot…"))
     screenshot_btn.set_use_underline(True)
     screenshot_btn.set_halign(Gtk.Align.CENTER)
-
-    style_context = screenshot_btn.get_style_context()
-    style_context.add_class("pill")
-    style_context.add_class("text-button")
-    style_context.add_class("suggested-action")
-
+    screenshot_btn.get_style_context().add_class("pill")
+    screenshot_btn.get_style_context().add_class("text-button")
+    screenshot_btn.get_style_context().add_class("suggested-action")
     screenshot_btn.set_action_name("app.screenshot")
 
     open_status_btn = Gtk.Button.new_with_label(_("_Open Image…"))
     open_status_btn.set_use_underline(True)
     open_status_btn.set_halign(Gtk.Align.CENTER)
-
-    style_context = open_status_btn.get_style_context()
-    style_context.add_class("pill")
-    style_context.add_class("text-button")
-
+    open_status_btn.get_style_context().add_class("pill")
+    open_status_btn.get_style_context().add_class("text-button")
     open_status_btn.set_action_name("app.open")
 
     button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
@@ -201,11 +205,15 @@ def create_status_page() -> Adw.StatusPage:
     button_box.append(screenshot_btn)
     button_box.append(open_status_btn)
 
+    main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=24)
+    main_box.set_halign(Gtk.Align.CENTER)
+    main_box.append(picker)
+    main_box.append(button_box)
+
     status_page = Adw.StatusPage.new()
-    status_page.set_icon_name("image-x-generic-symbolic")
-    status_page.set_title(_("No Image Loaded"))
+    status_page.set_title(_("Prepare an Image"))
     status_page.set_description(_("Drag and drop one here"))
-    status_page.set_child(button_box)
+    status_page.set_child(main_box)
 
     return status_page
 

--- a/gradia/ui/ui_parts.py
+++ b/gradia/ui/ui_parts.py
@@ -200,7 +200,7 @@ def create_status_page() -> Adw.StatusPage:
     open_status_btn.get_style_context().add_class("text-button")
     open_status_btn.set_action_name("app.open")
 
-    button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+    button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12 , margin_top=10)
     button_box.set_halign(Gtk.Align.CENTER)
     button_box.append(screenshot_btn)
     button_box.append(open_status_btn)
@@ -211,7 +211,7 @@ def create_status_page() -> Adw.StatusPage:
     main_box.append(button_box)
 
     status_page = Adw.StatusPage.new()
-    status_page.set_title(_("Prepare an Image"))
+    status_page.set_title(_("Enhance an Image"))
     status_page.set_description(_("Drag and drop one here"))
     status_page.set_child(main_box)
 

--- a/gradia/ui/window.py
+++ b/gradia/ui/window.py
@@ -186,18 +186,6 @@ class GradientWindow(Adw.ApplicationWindow):
         self.toolbar_view.set_content(self.main_box)
         self.toast_overlay.set_child(self.toolbar_view)
 
-        self.connect("notify::default-width", self._on_window_resize)
-        self.connect("notify::default-height", self._on_window_resize)
-
-    def _on_window_resize(self, *args: Any) -> None:
-        width: int = self.get_width()
-        if width < 800:
-            self.main_box.set_orientation(Gtk.Orientation.VERTICAL)
-            self.sidebar.set_size_request(-1, 200)
-        else:
-            self.main_box.set_orientation(Gtk.Orientation.HORIZONTAL)
-            self.sidebar.set_size_request(300, -1)
-
     def show(self) -> None:
         self.present()
 

--- a/gradia/ui/window.py
+++ b/gradia/ui/window.py
@@ -79,6 +79,7 @@ class GradientWindow(Adw.ApplicationWindow):
         self.create_action_with_param("load-drop", self.import_manager._on_drop_action)
         self.create_action("paste", lambda *_: self.import_manager.load_from_clipboard(), ["<Primary>v"])
         self.create_action("screenshot", lambda *_: self.import_manager.take_screenshot(), ["<Primary>a"])
+        self.create_action_with_param("open-path", lambda action, param: self.import_manager.load_from_file(param.get_string()))
 
         self.create_action("save", lambda *_: self.export_manager.save_to_file(), ["<Primary>s"], enabled=False)
         self.create_action("copy", lambda *_: self.export_manager.copy_to_clipboard(), ["<Primary>c"], enabled=False)

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -9,5 +9,6 @@ gradia/ui/ui_parts.py
 gradia/ui/window.py
 gradia/ui/image_exporters.py
 gradia/ui/image_loaders.py
-gradia/ui/drawing_overlay.py
-gradia/ui/drawing_actions.py
+gradia/ui/recent_picker.py
+gradia/overlay/drawing_overlay.py
+gradia/overlay/drawing_actions.py


### PR DESCRIPTION
This PR enhances the initial view by adding a grid that displays the user's most recent screenshots. Since most users typically open the app to edit a screenshot they just captured, this update aims to streamline their workflow and improve the overall user experience by providing quick access to recent images right from the start.

This sadly does need the added permission of the user's Screenshot folder, which will make the listing on Flathub look worse. But I personally find it worth it because it makes this, as well as other features like the auto-delete and overriding possible.

![image](https://github.com/user-attachments/assets/6380fc77-efe6-453c-8c81-69971d2433df)
