### PR TITLE
add censor annotation option

### DIFF
--- a/gradia/ui/ui_parts.py
+++ b/gradia/ui/ui_parts.py
@@ -239,7 +239,7 @@ def create_drawing_tools_group() -> Adw.PreferencesGroup:
         (DrawingMode.SQUARE, "box-small-outline-symbolic", 0, 1),
         (DrawingMode.CIRCLE, "circle-outline-thick-symbolic", 1, 1),
         (DrawingMode.HIGHLIGHTER, "marker-symbolic", 2, 1),
-        #(DrawingMode.CENSOR, "checkerboard-big-symbolic", 3, 1),
+        (DrawingMode.CENSOR, "checkerboard-big-symbolic", 3, 1),
         #(DrawingMode.NUMBER, "one-circle-symbolic", 4, 1),
     ]
 


### PR DESCRIPTION
This PR adds the censor function (pixelate). I designed this feature with security in mind. There are tools that can reverse engineer pixelated text, so my implementation tries to stop this by shuffling pixels after pixelation. This might look weird on images but should look fine enough on text, which I expect people mostly want to censor.