### PR TITLE
[Feature] Solid color and image background support

### DIFF
--- a/gradia/graphics/image.py
+++ b/gradia/graphics/image.py
@@ -1,0 +1,196 @@
+# Copyright (C) 2025 Alexander Vanhee
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Optional, Callable
+from gi.repository import Gtk, Gdk, Adw, GdkPixbuf, GLib
+from PIL import Image
+from gradia.graphics.background import Background
+import threading
+import tempfile
+import os
+
+class ImageBackground(Background):
+    def __init__(self, file_path: Optional[str] = None) -> None:
+        self.file_path: Optional[str] = file_path
+        self.image: Optional[Image.Image] = None
+
+        if file_path:
+            self.load_image(file_path)
+
+    def load_image(self, path: str) -> None:
+        self.file_path = path
+        try:
+            self.image = Image.open(path).convert("RGBA")
+        except Exception as e:
+            self.image = None
+            print(f"Error loading image: {e}")
+
+    def prepare_image(self, width: int, height: int) -> Optional[Image.Image]:
+        if not self.image:
+            return None
+
+        img = self.image
+        img_ratio = img.width / img.height
+        target_ratio = width / height
+
+        if img_ratio > target_ratio:
+            new_height = height
+            new_width = int(new_height * img_ratio)
+        else:
+            new_width = width
+            new_height = int(new_width / img_ratio)
+
+        img_resized = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
+        left = (new_width - width) // 2
+        top = (new_height - height) // 2
+        right = left + width
+        bottom = top + height
+
+        img_cropped = img_resized.crop((left, top, right, bottom))
+        return img_cropped
+
+    def get_name(self) -> str:
+        return f"image-{self.file_path or 'none'}"
+
+
+class ImageSelector:
+    def __init__(
+        self,
+        image_background: ImageBackground,
+        callback: Optional[Callable[[ImageBackground], None]] = None,
+        parent_window: Optional[Gtk.Window] = None
+    ) -> None:
+        self.image_background = image_background
+        self.callback = callback
+        self.preview_picture = Gtk.Picture()
+        self.widget = self._build()
+        self._update_preview()
+        self.parent_window = parent_window
+
+    def _build(self) -> Adw.PreferencesGroup:
+        group = Adw.PreferencesGroup(title=_("Image Background"))
+        button_row = Adw.ActionRow()
+        file_button = Gtk.Button(label=_("Select Image"), margin_start=8, margin_end=8, margin_top=8, margin_bottom=8)
+        file_button.connect("clicked", self._on_select_clicked)
+        button_row.set_child(file_button)
+        button_row.set_activatable(False)
+        group.add(button_row)
+
+        preview_row = Adw.ActionRow()
+        preview_row.set_activatable(False)
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, hexpand=True, halign=Gtk.Align.CENTER)
+        self.preview_picture.set_size_request(250, 88)
+        self.preview_picture.set_content_fit(Gtk.ContentFit.COVER)
+        frame = Gtk.Frame(margin_top=8, margin_bottom=8)
+        frame.set_child(self.preview_picture)
+        box.append(frame)
+        preview_row.set_child(box)
+        group.add(preview_row)
+
+        return group
+
+    def _on_select_clicked(self, _button: Gtk.Button) -> None:
+        dialog = Gtk.FileChooserDialog(
+            title=_("Select Background Image"),
+            action=Gtk.FileChooserAction.OPEN,
+            transient_for=self.parent_window,
+            modal=True
+        )
+        dialog.add_buttons(
+            "_Cancel", Gtk.ResponseType.CANCEL,
+            "_Open", Gtk.ResponseType.ACCEPT
+        )
+
+        filter_image = Gtk.FileFilter()
+        filter_image.set_name("Image files")
+        filter_image.add_mime_type("image/png")
+        filter_image.add_mime_type("image/jpeg")
+        filter_image.add_mime_type("image/webp")
+        filter_image.add_mime_type("image/avif")
+        dialog.add_filter(filter_image)
+
+        dialog.connect("response", self._on_file_dialog_response)
+        dialog.show()
+
+    def _on_file_dialog_response(self, dialog: Gtk.FileChooserDialog, response: int) -> None:
+        if response == Gtk.ResponseType.ACCEPT:
+            file_path = dialog.get_file().get_path()
+            if file_path:
+                self._load_image_async(file_path)
+        dialog.destroy()
+
+    def _load_image_async(self, file_path: str) -> None:
+        def load_in_background():
+            try:
+                self.image_background.load_image(file_path)
+                GLib.idle_add(self._on_image_loaded)
+
+            except Exception as e:
+                print(f"Error loading image: {e}")
+                GLib.idle_add(self._on_image_load_error)
+
+        thread = threading.Thread(target=load_in_background, daemon=True)
+        thread.start()
+
+    def _on_image_loaded(self) -> None:
+        self._update_preview()
+        if self.callback:
+            self.callback(self.image_background)
+
+    def _on_image_load_error(self) -> None:
+        pass
+
+    def _update_preview(self) -> None:
+        if self.image_background.image:
+
+            def save_and_update():
+                try:
+                    from PIL import Image
+                    image = self.image_background.image.copy()
+
+                    max_width = 400
+                    if image.width > max_width:
+                        ratio = max_width / image.width
+                        new_size = (int(image.width * ratio), int(image.height * ratio))
+                        image = image.resize(new_size, Image.LANCZOS)
+
+                    with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as temp_file:
+                        temp_path = temp_file.name
+                        image.save(temp_path, 'PNG')
+
+                    GLib.idle_add(self._set_preview_image, temp_path)
+
+                except Exception as e:
+                    print(f"Error saving preview: {e}")
+
+            thread = threading.Thread(target=save_and_update, daemon=True)
+            thread.start()
+        else:
+            self.preview_picture.set_paintable(None)
+
+    def _set_preview_image(self, temp_path: str) -> None:
+        self.preview_picture.set_filename(temp_path)
+        def cleanup_temp_file():
+            try:
+                import os
+                os.unlink(temp_path)
+            except:
+                pass
+            return False
+
+        GLib.timeout_add(100, cleanup_temp_file)
+        return False  

--- a/gradia/graphics/solid.py
+++ b/gradia/graphics/solid.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2025 Alexander Vanhee
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from collections.abc import Callable
+from typing import Optional
+from PIL import Image
+from gi.repository import Gtk, Gdk, Adw
+from gradia.graphics.background import Background
+
+
+class SolidBackground(Background):
+
+    def __init__(self, color: str = "#4A90E2", alpha: float = 1.0) -> None:
+        self.color = color
+        self.alpha = alpha
+
+    def get_name(self) -> str:
+        return f"solid-{self.color}-{self.alpha}"
+
+    def _hex_to_rgb(self, hex_color: str) -> tuple[int, int, int]:
+        hex_color = hex_color.lstrip('#')
+        return tuple(int(hex_color[i:i+2], 16) for i in (0, 2, 4))
+
+    def prepare_image(self, width: int, height: int) -> Image.Image:
+        rgb = self._hex_to_rgb(self.color)
+        alpha_value = int(self.alpha * 255)
+        return Image.new('RGBA', (width, height), (*rgb, alpha_value))
+
+
+class SolidSelector:
+
+    COMMON_COLORS = [
+        "#ffffff",
+        "#000000",
+        "#f66151",
+        "#33d17a",
+        "#3584e4",
+        "#f6d32d",
+        "#c061cb",
+        "#33c7de"
+    ]
+
+    def __init__(
+        self,
+        solid: SolidBackground,
+        callback: Optional[Callable[[SolidBackground], None]] = None
+    ) -> None:
+        self.solid = solid
+        self.callback = callback
+        self.color_button: Optional[Gtk.ColorButton] = None
+        self.widget = self._build()
+
+    def _build(self) -> Adw.PreferencesGroup:
+        group = Adw.PreferencesGroup(title=_("Solid Color Background"))
+        group.add(self._color_row())
+        group.add(self._common_colors_row())
+        return group
+
+    def _color_row(self) -> Adw.ActionRow:
+        row = Adw.ActionRow(title=_("Color"))
+        rgba = self._hex_alpha_to_rgba(self.solid.color, self.solid.alpha)
+        self.color_button = Gtk.ColorButton(
+            rgba=rgba,
+            use_alpha=True,
+            valign=Gtk.Align.CENTER
+        )
+        self.color_button.connect("color-set", self._on_color_changed)
+        row.add_suffix(self.color_button)
+        return row
+
+    def _common_colors_row(self) -> Adw.ActionRow:
+        row = Adw.ActionRow()
+        row.set_activatable(False)
+        row.set_selectable(False)
+
+        grid = Gtk.Grid()
+        grid.set_valign(Gtk.Align.CENTER)
+        grid.set_halign(Gtk.Align.CENTER)
+        grid.set_row_spacing(6)
+        grid.set_column_spacing(6)
+
+        columns = 4
+
+        for index, color in enumerate(self.COMMON_COLORS):
+            button = Gtk.Button()
+            button.set_valign(Gtk.Align.CENTER)
+            button.set_size_request(32, 32)
+            button.set_margin_top(7)
+            button.set_margin_bottom(6.95)
+
+            rgba = self._hex_alpha_to_rgba(color, 1.0)
+            css = f"""
+            button {{
+                background-color: {rgba.to_string()};
+                border-radius: 50%;
+                border: 1px solid @borders;
+            }}
+            """
+
+            style_provider = Gtk.CssProvider()
+            style_provider.load_from_data(css.encode())
+            Gtk.StyleContext.add_provider(
+                button.get_style_context(),
+                style_provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            )
+            button.connect("clicked", self._on_common_color_clicked, color)
+
+            row_pos = index // columns
+            col_pos = index % columns
+            grid.attach(button, col_pos, row_pos, 1, 1)
+
+        row.set_child(grid)
+        return row
+
+    def _on_common_color_clicked(self, button: Gtk.Button, color: str) -> None:
+        self.solid.color = color
+        self.solid.alpha = 1.0
+        if self.color_button:
+            self.color_button.set_rgba(self._hex_alpha_to_rgba(color, 1.0))
+        if self.callback:
+            self.callback(self.solid)
+
+    def _on_color_changed(self, button: Gtk.ColorButton) -> None:
+        rgba = button.get_rgba()
+        self.solid.color = self._rgba_to_hex(rgba)
+        self.solid.alpha = rgba.alpha
+        if self.callback:
+            self.callback(self.solid)
+
+    def _hex_alpha_to_rgba(self, hex_color: str, alpha: float) -> Gdk.RGBA:
+        rgba = Gdk.RGBA()
+        rgba.parse(hex_color)
+        rgba.alpha = alpha
+        return rgba
+
+    def _rgba_to_hex(self, rgba: Gdk.RGBA) -> str:
+        r = int(rgba.red * 255)
+        g = int(rgba.green * 255)
+        b = int(rgba.blue * 255)
+        return f"#{r:02x}{g:02x}{b:02x}"

--- a/gradia/overlay/transparency_overlay.py
+++ b/gradia/overlay/transparency_overlay.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2025 Alexander Vanhee
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from gi.repository import Gtk
+
+class TransparencyBackground(Gtk.DrawingArea):
+    def __init__(self):
+        super().__init__()
+        self.set_draw_func(self._on_draw, None)
+        self.picture_widget = None
+        self.square_size = 20
+
+    def set_picture_reference(self, picture):
+        self.picture_widget = picture
+        if picture:
+            picture.connect("notify::paintable", lambda *args: self.queue_draw())
+
+    def _get_image_bounds(self):
+        if not self.picture_widget or not self.picture_widget.get_paintable():
+            return 0, 0, self.get_width(), self.get_height()
+
+        widget_w = self.picture_widget.get_width()
+        widget_h = self.picture_widget.get_height()
+        img_w = self.picture_widget.get_paintable().get_intrinsic_width()
+        img_h = self.picture_widget.get_paintable().get_intrinsic_height()
+
+        if img_w <= 0 or img_h <= 0:
+            return 0, 0, widget_w, widget_h
+
+        scale = min(widget_w / img_w, widget_h / img_h)
+        disp_w = img_w * scale
+        disp_h = img_h * scale
+        offset_x = (widget_w - disp_w) / 2
+        offset_y = (widget_h - disp_h) / 2
+
+        return offset_x, offset_y, disp_w, disp_h
+
+    def _on_draw(self, area, cr, width, height, user_data):
+        """Draw checkerboard pattern only within image bounds"""
+        offset_x, offset_y, disp_w, disp_h = self._get_image_bounds()
+
+        light_gray = (0.9, 0.9, 0.9)
+        dark_gray = (0.7, 0.7, 0.7)
+
+        start_x = int(offset_x)
+        start_y = int(offset_y)
+        end_x = int(offset_x + disp_w)
+        end_y = int(offset_y + disp_h)
+
+        for y in range(start_y, end_y, self.square_size):
+            for x in range(start_x, end_x, self.square_size):
+                square_x = (x - start_x) // self.square_size
+                square_y = (y - start_y) // self.square_size
+                is_light = (square_x + square_y) % 2 == 0
+                color = light_gray if is_light else dark_gray
+                cr.set_source_rgb(*color)
+
+                square_w = min(self.square_size, end_x - x)
+                square_h = min(self.square_size, end_y - y)
+
+                cr.rectangle(x, y, square_w, square_h)
+                cr.fill()

--- a/gradia/ui/background_selector.py
+++ b/gradia/ui/background_selector.py
@@ -1,0 +1,121 @@
+# Copyright (C) 2025 Alexander Vanhee
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from collections.abc import Callable
+from typing import Optional
+from gi.repository import Gtk, Adw
+from gradia.graphics.gradient import GradientSelector, GradientBackground
+from gradia.graphics.solid import SolidSelector, SolidBackground
+from gradia.graphics.image import ImageSelector, ImageBackground
+from gradia.graphics.background import Background
+
+MODES = ["solid", "gradient", "image"]
+
+class BackgroundSelector:
+
+    def __init__(
+        self,
+        gradient: GradientBackground,
+        solid: SolidBackground,
+        image: ImageBackground,
+        callback: Optional[Callable[[Background], None]] = None,
+        initial_mode: str = "gradient",
+        window: Optional[Gtk.Window] = None
+    ) -> None:
+        self.gradient = gradient
+        self.solid = solid
+        self.image = image
+        self.callback = callback
+        self.current_mode = initial_mode if initial_mode in MODES else "gradient"
+        self.initial_mode = self.current_mode
+
+        self.gradient_selector = GradientSelector(gradient, self._on_gradient_changed)
+        self.solid_selector = SolidSelector(solid, self._on_solid_changed)
+        self.image_selector = ImageSelector(image, self._on_image_changed, window)
+
+        self.widget = self._build()
+
+    def _build(self) -> Gtk.Box:
+        main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+
+        self.toggle_group = Adw.ToggleGroup()
+        self.toggle_group.add_css_class("round")
+        self.toggle_group.set_homogeneous(True)
+
+        self.toggle_buttons = {}
+
+        for mode in MODES:
+            toggle = Adw.Toggle(name=mode)
+            label = mode.capitalize()
+            toggle.set_child(Gtk.Label(label=_(label)))
+            self.toggle_group.add(toggle)
+            self.toggle_buttons[mode] = toggle
+
+        self.toggle_group.set_active_name(self.current_mode)
+        self.toggle_group.connect("notify::active-name", self._on_group_changed)
+        main_box.append(self.toggle_group)
+
+        self.stack = Gtk.Stack()
+        self.stack.set_transition_type(Gtk.StackTransitionType.CROSSFADE)
+        self.stack.set_transition_duration(250)
+        self.stack.set_hexpand(True)
+        self.stack.set_valign(Gtk.Align.START)
+
+        self.stack.add_named(self.solid_selector.widget, "solid")
+        self.stack.add_named(self.gradient_selector.widget, "gradient")
+        self.stack.add_named(self.image_selector.widget, "image")
+        self.stack.set_visible_child_name(self.current_mode)
+
+        main_box.append(self.stack)
+
+        return main_box
+
+    def _on_group_changed(self, group: Adw.ToggleGroup, _param) -> None:
+        active_name = group.get_active_name()
+        if active_name in MODES and active_name != self.current_mode:
+            self.current_mode = active_name
+            self.stack.set_visible_child_name(active_name)
+            self._notify_current()
+
+    def _on_gradient_changed(self, gradient: GradientBackground) -> None:
+        if self.current_mode == "gradient":
+            self._notify_current()
+
+    def _on_solid_changed(self, solid: SolidBackground) -> None:
+        if self.current_mode == "solid":
+            self._notify_current()
+
+    def _on_image_changed(self, image: ImageBackground) -> None:
+        if self.current_mode == "image":
+            self._notify_current()
+
+    def _notify_current(self) -> None:
+        if self.callback:
+            current_background = {
+                "gradient": self.gradient,
+                "solid": self.solid,
+                "image": self.image
+            }.get(self.current_mode)
+            self.callback(current_background)
+
+    def get_current_background(self) -> Background:
+        return {
+            "gradient": self.gradient,
+            "solid": self.solid,
+            "image": self.image
+        }.get(self.current_mode)
+

--- a/gradia/ui/ui_parts.py
+++ b/gradia/ui/ui_parts.py
@@ -372,7 +372,7 @@ def create_drawing_tools_group() -> Adw.PreferencesGroup:
     return tools_group
 
 def create_sidebar_ui(
-    gradient_selector_widget: Gtk.Widget,
+    background_selector_widget: Gtk.Widget,
     on_padding_changed: Callable[[Adw.SpinRow], None],
     on_corner_radius_changed: Callable[[Adw.SpinRow], None],
     on_aspect_ratio_changed: Callable[[Gtk.Entry], None],
@@ -388,7 +388,7 @@ def create_sidebar_ui(
 
     drawing_tools_group = create_drawing_tools_group()
     controls_box.append(drawing_tools_group)
-    controls_box.append(gradient_selector_widget)
+    controls_box.append(background_selector_widget)
 
     # Add grouped UI elements
     padding_group, padding_row, aspect_ratio_entry = create_image_options_group(

--- a/gradia/ui/ui_parts.py
+++ b/gradia/ui/ui_parts.py
@@ -21,6 +21,7 @@ from gi.repository import Gtk, Gio, Adw, Gdk, GLib
 
 from gradia.overlay.drawing_actions import DrawingMode
 from gradia.overlay.drawing_overlay import DrawingOverlay
+from gradia.overlay.transparency_overlay import TransparencyBackground
 from gradia.ui.recent_picker import RecentPicker
 
 @Gtk.Template(resource_path="/be/alexandervanhee/gradia/ui/header_bar.ui")
@@ -56,9 +57,22 @@ def create_image_stack() -> tuple[Gtk.Stack, Gtk.Picture, Adw.Spinner, 'DrawingO
     stack.set_transition_duration(200)
 
     picture = create_picture_widget()
+
+    transparency_background = TransparencyBackground()
+    transparency_background.set_hexpand(True)
+    transparency_background.set_vexpand(True)
+    transparency_background.set_picture_reference(picture)
+
+    image_overlay = Gtk.Overlay()
+    image_overlay.set_child(transparency_background)
+    image_overlay.add_overlay(picture)
+
     drawing_overlay = create_drawing_overlay(picture)
-    overlay, controls_overlay = create_image_overlay(picture, drawing_overlay)
+
+    overlay, controls_overlay = create_image_overlay(image_overlay, drawing_overlay)
+
     drawing_overlay.set_controls_overlay(controls_overlay)
+
     stack.add_named(overlay, "image")
 
     spinner_box, spinner = create_spinner_widget()
@@ -76,12 +90,13 @@ def create_image_stack() -> tuple[Gtk.Stack, Gtk.Picture, Adw.Spinner, 'DrawingO
     top_bar.set_show_start_title_buttons(False)
     top_bar.set_show_end_title_buttons(True)
     top_bar.set_title_widget(Gtk.Box())
-
     top_bar.set_valign(Gtk.Align.START)
     top_bar.set_halign(Gtk.Align.FILL)
+
     main_overlay.add_overlay(top_bar)
 
     return stack, picture, spinner, drawing_overlay, controls_overlay, main_overlay
+
 
 def create_image_overlay(picture: Gtk.Picture, drawing_overlay: 'DrawingOverlay') -> Gtk.Overlay:
     overlay = Gtk.Overlay.new()

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,11 +5,14 @@ data/be.alexandervanhee.gradia.desktop.in
 data/be.alexandervanhee.gradia.metainfo.xml.in
 data/be.alexandervanhee.gradia.gschema.xml
 gradia/graphics/gradient.py
+gradia/graphics/solid.py
+gradia/graphics/image.py
 gradia/ui/ui_parts.py
 gradia/ui/window.py
 gradia/ui/image_exporters.py
 gradia/ui/image_loaders.py
 gradia/ui/recent_picker.py
+gradia/ui/background_selector.py
 gradia/overlay/drawing_overlay.py
 gradia/overlay/drawing_actions.py
 data/ui/controls_overlay.blp


### PR DESCRIPTION
This PR adds support for solid color and image backgrounds from #5.

I’ve decided not to support pattern-based backgrounds at this time, as they’re probably a bit out of scope for this app. Generating those kinds of backgrounds is likely better suited for a separate app.

Closes #18
Closes #5 
Closes #9 

![Screenshot From 2025-06-06 21-00-35](https://github.com/user-attachments/assets/91eecda4-3801-4eba-92d1-6cfcf5fef5a6)

![image](https://github.com/user-attachments/assets/9e16c6c6-0918-4366-ba13-0edd176ade9c)
