### PR TITLE
Support opening with `Open With...` dialog

### DIFF
--- a/data/be.alexandervanhee.gradia.desktop.in.in
+++ b/data/be.alexandervanhee.gradia.desktop.in.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Gradia
 Comment=Make your images ready for the world
-Exec=gradia
+Exec=gradia %U
 Icon=@APP_ID@
 Terminal=false
 Type=Application


### PR DESCRIPTION
Per [`.desktop` entry specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html), `%U` field code passes a list of URLs to the program, allowing us to open images with Gradia using `Open With...` dialog. Fixes #17.

Thanks to @ai for suggesting this!