### PR TITLE
Create snapcraft.yaml

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -25,23 +25,29 @@ parts:
     prime:
       - -snap/gradia
   deps:
-    plugin: nil
-    override-build: |
-      python3 -m pip install --target=$CRAFT_PART_INSTALL/usr/lib/python3/dist-packages Wand==0.6.13 Pillow
-      snapcraftctl build
+    plugin: python
+    source: .
+    python-packages:
+      - Wand==0.6.13
+      - Pillow
+    stage:
+      - -bin/activate*
+      - -bin/Activate.ps1
+      - -bin/python*
+      - -bin/pip*
+      - -pyvenv.cfg
+      - -lib/*/*/setup*
+      - -lib/*/*/pkg*
+      - -lib/*/*/pip*
+      - -lib/*/*/_dist*
+      - -share
+      - -include
+    organize:
+      lib/python3.12/site-packages: usr/lib/python3/dist-packages
+
     stage-packages:
       - libzstd1
       - curl
-
-    prime:
-      - -bin
-      - -pyvenv.cfg
-      - -include
-      - -lib64
-      - -lib
-      - -usr/lib/*/*/pip*
-      - -usr/lib/*/*/setup*
-      - -usr/share
   cleanup:
     after:
       - deps

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -2,7 +2,10 @@ name: gradia
 version: '1.5.0'
 summary: Make your screenshots ready for all
 description: |
-    Gradia helps you quickly prepare your screenshots for sharing by fixing common issues   like transparency and awkward sizing. With simple tools to add backgrounds, adjust aspect ratios, and annotate images, you can enhance your screenshots to look professional and consistent across social media, blogs, and other platforms on the internet.
+  Gradia helps you quickly prepare your screenshots for sharing by fixing common issues
+  like transparency and awkward sizing. With simple tools to add backgrounds, adjust aspect
+  ratios, and annotate images, you can enhance your screenshots to look professional and
+  consistent across social media, blogs, and other platforms on the internet.
 
 base: core24
 adopt-info: gradia
@@ -11,7 +14,51 @@ grade: stable
 confinement: strict
 
 parts:
+  libadwaita:
+    plugin: meson
+    source: https://gitlab.gnome.org/GNOME/libadwaita.git
+    source-tag: '1.7.4'
+    source-depth: 1
+    build-packages:
+      - libgtk-4-dev
+      - libglib2.0-dev
+      - gobject-introspection
+      - libgirepository1.0-dev
+      - sassc
+      - gettext
+      - pkg-config
+      - libxml2-utils
+      - gtk-doc-tools
+    meson-parameters:
+      - --prefix=/usr
+      - -Dgtk_doc=false
+      - -Dintrospection=enabled
+      - -Dvapi=false
+      - -Dtests=false
+      - -Dexamples=false
+      - -Dbuildtype=release
+      - -Ddefault_library=both
+      - -Dc_args=-Wno-error=format-nonliteral
+      - -Dc_args=-Wno-error=format=2
+      - -Dc_args=-Wno-error=format-security
+      - -Dc_args=-Wno-error=incompatible-pointer-types
+      - -Dc_args=-Wno-error=missing-declarations
+      - -Dc_args=-Wno-error=overflow
+      - -Dc_args=-Wno-error=return-type
+      - -Dc_args=-Wno-error=shift-count-overflow
+      - -Dc_args=-Wno-error=shift-overflow=2
+      - -Dc_args=-Wno-error=implicit-fallthrough=3
+      - -Dc_args=-Wno-error=redundant-decls
+      - -Dc_args=-U_FORTIFY_SOURCE
+    override-build: |
+      unset CFLAGS || true
+      unset CXXFLAGS || true
+      craftctl default
+    prime:
+      - usr/lib
+
   gradia:
+    after: [libadwaita]
     plugin: meson
     source: https://github.com/AlexanderVanhee/Gradia.git
     source-tag: 'v1.5.0'
@@ -28,7 +75,7 @@ parts:
     organize:
       snap/gradia/current: .
     prime:
-      - -snap/gradia
+      - .
 
   deps:
     plugin: nil
@@ -45,6 +92,7 @@ parts:
       - libzip4t64
       - libzstd1
       - libraqm0
+      - libavif-dev
     prime:
       - -bin
       - -pyvenv.cfg
@@ -81,6 +129,7 @@ apps:
     extensions: [gnome]
     environment:
       PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$LD_LIBRARY_PATH
       GDK_DEBUG: portals
     plugs:
       - home

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -1,0 +1,87 @@
+name: gradia
+version: '1.4.3'
+summary: Make your screenshots ready for all
+description: |
+    Gradia helps you quickly prepare your screenshots for sharing by fixing common issues   like transparency and awkward sizing. With simple tools to add backgrounds, adjust aspect ratios, and annotate images, you can enhance your screenshots to look professional and consistent across social media, blogs, and other platforms on the internet.
+
+base: core24
+adopt-info: gradia
+compression: lzo
+grade: stable
+confinement: strict
+
+parts:
+  gradia:
+    plugin: meson
+    source: https://github.com/AlexanderVanhee/Gradia.git
+    source-tag: 'v1.4.3'
+    source-depth: 1
+    meson-parameters:
+      - --prefix=/snap/gradia/current/usr
+      - -Dbuildtype=release
+    build-snaps:
+      - blueprint-compiler/latest/edge
+    override-build: |
+      craftctl default
+      sed -i '1c#!/usr/bin/env python3' $CRAFT_PART_INSTALL/snap/gradia/current/usr/bin/gradia
+    parse-info: [usr/share/appdata/be.alexandervanhee.gradia.appdata.xml]
+    organize:
+      snap/gradia/current: .
+    prime:
+      - -snap/gradia
+
+  deps:
+    plugin: nil
+    override-build: |
+      python3 -m pip install --target=$CRAFT_PART_INSTALL/usr/lib/python3/dist-packages Wand==0.6.13 Pillow
+      snapcraftctl build
+    stage-packages:
+      - liblqr-1-0
+      - libraw23t64
+      - libopenexr-3-1-30
+      - libheif1
+      - libjpeg62
+      - libwmf0.2-7
+      - libzip4t64
+      - libzstd1
+      - libraqm0
+    prime:
+      - -bin
+      - -pyvenv.cfg
+      - -include
+      - -lib64
+      - -lib
+      - -usr/lib/*/*/pip*
+      - -usr/lib/*/*/setup*
+      - -usr/share
+
+  cleanup:
+    after:
+      - deps
+    plugin: nil
+    build-snaps:
+      - core24
+      - gnome-46-2404
+    override-prime: |
+      set -eux
+      for snap in "core24" "gnome-46-2404"; do
+          cd "/snap/$snap/current" && find . -type f,l -exec rm -rf "$CRAFT_PRIME/{}" \;
+      done
+
+slots:
+  gradia:
+    interface: dbus
+    bus: session
+    name: be.alexandervanhee.gradia
+
+apps:
+  gradia:
+    command: usr/bin/gradia
+    common-id: be.alexandervanhee.gradia
+    extensions: [gnome]
+    environment:
+      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      GDK_DEBUG: portals
+    plugs:
+      - home
+

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -2,97 +2,37 @@ name: gradia
 version: '1.5.0'
 summary: Make your screenshots ready for all
 description: |
-  Gradia helps you quickly prepare your screenshots for sharing by fixing common issues
-  like transparency and awkward sizing. With simple tools to add backgrounds, adjust aspect
-  ratios, and annotate images, you can enhance your screenshots to look professional and
-  consistent across social media, blogs, and other platforms on the internet.
-
+    Gradia helps you quickly prepare your screenshots for sharing by fixing common issues   like transparency and awkward sizing. With simple tools to add backgrounds, adjust aspect ratios, and annotate images, you can enhance your screenshots to look professional and consistent across social media, blogs, and other platforms on the internet.
 base: core24
 adopt-info: gradia
 compression: lzo
 grade: stable
 confinement: strict
-
 parts:
-  libadwaita:
-    plugin: meson
-    source: https://gitlab.gnome.org/GNOME/libadwaita.git
-    source-tag: '1.7.4'
-    source-depth: 1
-    build-packages:
-      - libgtk-4-dev
-      - libglib2.0-dev
-      - gobject-introspection
-      - libgirepository1.0-dev
-      - sassc
-      - gettext
-      - pkg-config
-      - libxml2-utils
-      - gtk-doc-tools
-    meson-parameters:
-      - --prefix=/usr
-      - -Dgtk_doc=false
-      - -Dintrospection=enabled
-      - -Dvapi=false
-      - -Dtests=false
-      - -Dexamples=false
-      - -Dbuildtype=release
-      - -Ddefault_library=both
-      - -Dc_args=-Wno-error=format-nonliteral
-      - -Dc_args=-Wno-error=format=2
-      - -Dc_args=-Wno-error=format-security
-      - -Dc_args=-Wno-error=incompatible-pointer-types
-      - -Dc_args=-Wno-error=missing-declarations
-      - -Dc_args=-Wno-error=overflow
-      - -Dc_args=-Wno-error=return-type
-      - -Dc_args=-Wno-error=shift-count-overflow
-      - -Dc_args=-Wno-error=shift-overflow=2
-      - -Dc_args=-Wno-error=implicit-fallthrough=3
-      - -Dc_args=-Wno-error=redundant-decls
-      - -Dc_args=-U_FORTIFY_SOURCE
-    override-build: |
-      unset CFLAGS || true
-      unset CXXFLAGS || true
-      craftctl default
-    prime:
-      - usr/lib
-
   gradia:
-    after: [libadwaita]
     plugin: meson
     source: https://github.com/AlexanderVanhee/Gradia.git
-    source-tag: 'v1.5.0'
+    source-commit: a9daeb419511ee8868abd5fc50ef3ad60856a3a9
     source-depth: 1
     meson-parameters:
       - --prefix=/snap/gradia/current/usr
       - -Dbuildtype=release
     build-snaps:
-      - blueprint-compiler/latest/edge
-    override-build: |
-      craftctl default
-      sed -i '1c#!/usr/bin/env python3' $CRAFT_PART_INSTALL/snap/gradia/current/usr/bin/gradia
-    parse-info: [usr/share/appdata/be.alexandervanhee.gradia.appdata.xml]
+      - blueprint-compiler
+    parse-info: [ usr/share/metainfo/be.alexandervanhee.gradia.metainfo.xml ]
     organize:
       snap/gradia/current: .
     prime:
-      - .
-
+      - -snap/gradia
   deps:
     plugin: nil
     override-build: |
       python3 -m pip install --target=$CRAFT_PART_INSTALL/usr/lib/python3/dist-packages Wand==0.6.13 Pillow
       snapcraftctl build
     stage-packages:
-      - liblqr-1-0
-      - libraw23t64
-      - libopenexr-3-1-30
-      - libheif1
-      - libjpeg62
-      - libwmf0.2-7
-      - libzip4t64
       - libzstd1
-      - libraqm0
-      - libavif-dev
+      - curl
+
     prime:
       - -bin
       - -pyvenv.cfg
@@ -102,7 +42,6 @@ parts:
       - -usr/lib/*/*/pip*
       - -usr/lib/*/*/setup*
       - -usr/share
-
   cleanup:
     after:
       - deps
@@ -115,13 +54,11 @@ parts:
       for snap in "core24" "gnome-46-2404"; do
           cd "/snap/$snap/current" && find . -type f,l -exec rm -rf "$CRAFT_PRIME/{}" \;
       done
-
 slots:
   gradia:
     interface: dbus
     bus: session
     name: be.alexandervanhee.gradia
-
 apps:
   gradia:
     command: usr/bin/gradia
@@ -129,7 +66,7 @@ apps:
     extensions: [gnome]
     environment:
       PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
-      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$LD_LIBRARY_PATH
-      GDK_DEBUG: portals
     plugs:
       - home
+      - network
+      - network-status

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: gradia
-version: '1.4.3'
+version: '1.5.0'
 summary: Make your screenshots ready for all
 description: |
     Gradia helps you quickly prepare your screenshots for sharing by fixing common issues   like transparency and awkward sizing. With simple tools to add backgrounds, adjust aspect ratios, and annotate images, you can enhance your screenshots to look professional and consistent across social media, blogs, and other platforms on the internet.
@@ -14,7 +14,7 @@ parts:
   gradia:
     plugin: meson
     source: https://github.com/AlexanderVanhee/Gradia.git
-    source-tag: 'v1.4.3'
+    source-tag: 'v1.5.0'
     source-depth: 1
     meson-parameters:
       - --prefix=/snap/gradia/current/usr
@@ -84,4 +84,3 @@ apps:
       GDK_DEBUG: portals
     plugs:
       - home
-

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -22,8 +22,6 @@ parts:
     parse-info: [ usr/share/metainfo/be.alexandervanhee.gradia.metainfo.xml ]
     organize:
       snap/gradia/current: .
-    prime:
-      - -snap/gradia
   deps:
     plugin: python
     source: .


### PR DESCRIPTION
I have created a Snapcraft build file that generates a snap package, but the app cannot launch because of an outdated libadwaita package. I either have to wait for them until they support `gnome-47` or later, or find some other fix.

```gradia
Traceback (most recent call last):
  File "/snap/gradia/x1/usr/bin/gradia", line 58, in <module>
    from gradia import main
  File "/snap/gradia/current/usr/share/gradia/gradia/main.py", line 29, in <module>
    from gradia.ui.window import GradientWindow
  File "/snap/gradia/current/usr/share/gradia/gradia/ui/window.py", line 32, in <module>
    from gradia.ui.background_selector import BackgroundSelector
  File "/snap/gradia/current/usr/share/gradia/gradia/ui/background_selector.py", line 33, in <module>
    class BackgroundSelector(Adw.Bin):
  File "/snap/gradia/current/usr/share/gradia/gradia/ui/background_selector.py", line 36, in BackgroundSelector
    toggle_group: Adw.ToggleGroup = Gtk.Template.Child()
                  ^^^^^^^^^^^^^^^
  File "/snap/gradia/x1/gnome-platform/usr/lib/python3/dist-packages/gi/module.py", line 127, in __getattr__
    raise AttributeError("%r object has no attribute %r" % (
AttributeError: 'gi.repository.Adw' object has no attribute 'ToggleGroup'
```

closes #102 