### PR TITLE
Rename `Settings` to `Preferences`

### DIFF
--- a/data/gradia.gresource.xml.in
+++ b/data/gradia.gresource.xml.in
@@ -12,7 +12,7 @@
     <file preprocess="xml-stripblanks">ui/recent_picker.ui</file>
     <file preprocess="xml-stripblanks">ui/text_entry_popover.ui</file>
     <file preprocess="xml-stripblanks">ui/welcome_page.ui</file>
-    <file preprocess="xml-stripblanks">ui/settings_window.ui</file>
+    <file preprocess="xml-stripblanks">ui/preferences_window.ui</file>
     <file preprocess="xml-stripblanks">ui/confirm_close_dialog.ui</file>
     <file>style.css</file>
     <file>help.txt</file>

--- a/data/ui/image_sidebar.blp
+++ b/data/ui/image_sidebar.blp
@@ -204,8 +204,8 @@ menu app_menu {
   }
   section {
     item {
-      label: _("Settings");
-      action: "app.settings";
+      label: _("Preferences");
+      action: "app.preferences";
     }
     item {
       label: _("Keyboard Shortcuts");

--- a/data/ui/meson.build
+++ b/data/ui/meson.build
@@ -11,7 +11,7 @@ blueprints = custom_target('blueprints',
     'recent_picker.blp',
     'text_entry_popover.blp',
     'welcome_page.blp',
-    'settings_window.blp',
+    'preferences_window.blp',
     'confirm_close_dialog.blp'
   ),
   output: '.',

--- a/data/ui/preferences_window.blp
+++ b/data/ui/preferences_window.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $GradiaSettingsWindow : Adw.PreferencesWindow {
+template $GradiaPreferencesWindow : Adw.PreferencesWindow {
   default-width: 600;
   default-height: 500;
   title: _("Options");

--- a/data/ui/welcome_page.blp
+++ b/data/ui/welcome_page.blp
@@ -69,8 +69,8 @@ template $GradiaWelcomePage : Adw.Bin {
 menu app_menu {
   section {
     item {
-      label: _("Settings");
-      action: "app.settings";
+      label: _("Preferences");
+      action: "app.preferences";
     }
     item {
       label: _("Keyboard Shortcuts");

--- a/gradia/ui/image_exporters.py
+++ b/gradia/ui/image_exporters.py
@@ -74,7 +74,7 @@ class BaseImageExporter:
         """Ensure processed image is available for export"""
         if not self.window.processed_pixbuf:
             raise Exception("No processed image available for export")
-        return False 
+        return False
 
 
 class FileDialogExporter(BaseImageExporter):

--- a/gradia/ui/preferences_window.py
+++ b/gradia/ui/preferences_window.py
@@ -1,4 +1,4 @@
-# settings_window.py
+# preferences_window.py
 # Copyright (C) 2025 Alexander Vanhee
 #
 # This program is free software: you can redistribute it and/or modify
@@ -92,9 +92,9 @@ def get_command_for_screenshot_type(screenshot_type: str) -> str:
         return f"gradia --screenshot={screenshot_type}"
 
 
-@Gtk.Template(resource_path=f"{rootdir}/ui/settings_window.ui")
-class SettingsWindow(Adw.PreferencesWindow):
-    __gtype_name__ = 'GradiaSettingsWindow'
+@Gtk.Template(resource_path=f"{rootdir}/ui/preferences_window.ui")
+class PreferencesWindow(Adw.PreferencesWindow):
+    __gtype_name__ = 'GradiaPreferencesWindow'
 
     location_group: Adw.PreferencesGroup = Gtk.Template.Child()
     folder_expander: Adw.ExpanderRow = Gtk.Template.Child()

--- a/gradia/ui/ui_parts.py
+++ b/gradia/ui/ui_parts.py
@@ -187,7 +187,7 @@ def create_shortcuts_dialog(parent: Optional[Gtk.Window] = None) -> Gtk.Shortcut
             "title": _("General"),
             "shortcuts": [
                 (_("Keyboard Shortcuts"), "<Ctrl>question"),
-                (_("Settings"), "<Ctrl>comma"),
+                (_("Preferences"), "<Ctrl>comma"),
                 (_("Toggle Utility Pane"), "F9"),
             ]
         }

--- a/gradia/ui/window.py
+++ b/gradia/ui/window.py
@@ -159,7 +159,7 @@ class GradiaMainWindow(Adw.ApplicationWindow):
 
         self.create_action("delete-screenshots", lambda *_: self._create_delete_screenshots_dialog(), enabled=False)
 
-        self.create_action("settings", self._on_preferences_activated, ['<primary>comma'])
+        self.create_action("preferences", self._on_preferences_activated, ['<primary>comma'])
         self.create_action("toggle-utility-pane", self._on_toggle_utility_pane_activated, ['F9'])
 
         self.create_action("set-screenshot-folder",  lambda action, param: self.set_screenshot_subfolder(param.get_string()), vt="s")

--- a/gradia/ui/window.py
+++ b/gradia/ui/window.py
@@ -36,7 +36,7 @@ from gradia.ui.image_sidebar import ImageSidebar
 from gradia.ui.ui_parts import *
 from gradia.ui.welcome_page import WelcomePage
 from gradia.utils.aspect_ratio import *
-from gradia.ui.settings_window import SettingsWindow
+from gradia.ui.preferences_window import PreferencesWindow
 from gradia.backend.settings import Settings
 from gradia.constants import rootdir  # pyright: ignore
 from gradia.ui.dialog.delete_screenshots_dialog import DeleteScreenshotsDialog
@@ -159,7 +159,7 @@ class GradiaMainWindow(Adw.ApplicationWindow):
 
         self.create_action("delete-screenshots", lambda *_: self._create_delete_screenshots_dialog(), enabled=False)
 
-        self.create_action("settings", self._on_settings_activated, ['<primary>comma'])
+        self.create_action("settings", self._on_preferences_activated, ['<primary>comma'])
         self.create_action("toggle-utility-pane", self._on_toggle_utility_pane_activated, ['F9'])
 
         self.create_action("set-screenshot-folder",  lambda action, param: self.set_screenshot_subfolder(param.get_string()), vt="s")
@@ -421,9 +421,9 @@ class GradiaMainWindow(Adw.ApplicationWindow):
             self._show_notification
         )
 
-    def _on_settings_activated(self, action: Gio.SimpleAction, param) -> None:
-        settings_window = SettingsWindow(self)
-        settings_window.present()
+    def _on_preferences_activated(self, action: Gio.SimpleAction, param) -> None:
+        preferences_window = PreferencesWindow(self)
+        preferences_window.present()
 
     def set_screenshot_subfolder(self, subfolder) -> None:
         Settings().screenshot_subfolder = subfolder

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -16,7 +16,7 @@ gradia/ui/background_selector.py
 gradia/ui/drawing_tools_group.py
 gradia/overlay/drawing_overlay.py
 gradia/overlay/drawing_actions.py
-gradia/ui/settings_window.py
+gradia/ui/preferences_window.py
 gradia/ui/dialog/confirm_close_dialog.py
 gradia/ui/dialog/delete_screenshots_dialog.py
 gradia/app_constants.py
@@ -33,5 +33,5 @@ data/ui/recent_picker.blp
 data/ui/text_entry_popover.blp
 data/ui/welcome_page.blp
 data/ui/welcome_page.blp
-data/ui/settings_window.blp
+data/ui/preferences_window.blp
 data/ui/confirm_close_dialog.blp


### PR DESCRIPTION
Rename `Settings` window to `Preferences`, to be in line with most GNOME apps.