### PR TITLE
Use more user-friendly language when sharing an image

### DIFF
--- a/data/ui/image_sidebar.blp
+++ b/data/ui/image_sidebar.blp
@@ -167,11 +167,12 @@ template $GradiaImageSidebar : Adw.Bin {
           "pill"
         ]
       }
-      Gtk.Button command_button {
+      Gtk.Button share_button {
         icon-name: "share-symbolic";
-        tooltip-text: _("Run Upload Command");
+        tooltip-text: _("Share Image");
         action-name: "app.command";
         width-request: 45;
+
         styles [
           "raised",
           "circular"

--- a/gradia/ui/image_sidebar.py
+++ b/gradia/ui/image_sidebar.py
@@ -55,7 +55,7 @@ class ImageSidebar(Adw.Bin):
     filename_row: Adw.ActionRow = Gtk.Template.Child()
     location_row: Adw.ActionRow = Gtk.Template.Child()
     processed_size_row: Adw.ActionRow = Gtk.Template.Child()
-    command_button: Gtk.Button = Gtk.Template.Child()
+    share_button: Gtk.Button = Gtk.Template.Child()
 
     def __init__(
         self,

--- a/gradia/ui/ui_parts.py
+++ b/gradia/ui/ui_parts.py
@@ -52,6 +52,7 @@ def create_shortcuts_dialog(parent: Optional[Gtk.Window] = None) -> Gtk.Shortcut
                 (_("Save to File"), "<Ctrl>S"),
                 (_("Copy Image to Clipboard"), "<Ctrl>C"),
                 (_("Paste From Clipboard"), "<Ctrl>V"),
+                (_("Share Image"), "<Ctrl>M"),
             ]
         },
         {

--- a/gradia/ui/window.py
+++ b/gradia/ui/window.py
@@ -450,20 +450,20 @@ class GradiaMainWindow(Adw.ApplicationWindow):
 
     def _run_custom_command(self) -> None:
         if Settings().show_export_confirm_dialog:
-            dialog = Adw.MessageDialog.new(
-                parent=self.get_root(),
+            provider_name = Settings().provider_name
+
+            dialog = Adw.AlertDialog.new(
                 heading=_("Confirm Upload"),
-                body=_("Are you sure you want to upload this image?")
+                body=_(f"Are you sure you want to upload this image to {provider_name}?")
             )
             dialog.add_response("cancel", _("Cancel"))
             dialog.add_response("confirm", _("Upload"))
             dialog.set_default_response("cancel")
-            dialog.set_size_request(350, -1)
             dialog.set_response_appearance("confirm", Adw.ResponseAppearance.SUGGESTED)
 
             dialog.connect("response", lambda dialog, response_id:
                           self.export_manager.run_custom_command() if response_id == "confirm" else None)
 
-            dialog.present()
+            dialog.present(self.get_root())
         else:
             self.export_manager.run_custom_command()

--- a/gradia/ui/window.py
+++ b/gradia/ui/window.py
@@ -79,7 +79,6 @@ class GradiaMainWindow(Adw.ApplicationWindow):
         self.image_path: Optional[str] = None
         self.processed_path: Optional[str] = None
         self.processed_pixbuf: Optional[Gdk.Pixbuf] = None
-        self.command_button = None
         self.image_ready = False
 
         self.export_manager: ExportManager = ExportManager(self, temp_dir)
@@ -144,7 +143,7 @@ class GradiaMainWindow(Adw.ApplicationWindow):
 
         self.create_action("save", lambda *_: self.export_manager.save_to_file(), ["<Primary>s"], enabled=False)
         self.create_action("copy", lambda *_: self.export_manager.copy_to_clipboard(), ["<Primary>c"], enabled=False)
-        self.create_action("command", lambda *_: self._run_custom_command(), enabled=False)
+        self.create_action("command", lambda *_: self._run_custom_command(), ["<Primary>m"], enabled=False)
 
         self.create_action("quit", lambda *_: self.close(), ["<Primary>w"])
 
@@ -194,7 +193,7 @@ class GradiaMainWindow(Adw.ApplicationWindow):
         self.sidebar.set_size_request(self.SIDEBAR_WIDTH, -1)
         self.sidebar.set_visible(False)
 
-        self.command_button = self.sidebar.command_button
+        self.share_button = self.sidebar.share_button
 
     def _setup(self) -> None:
         self.split_view.set_sidebar(self.sidebar)
@@ -427,7 +426,7 @@ class GradiaMainWindow(Adw.ApplicationWindow):
         action = self.app.lookup_action('command')
         if action:
             action.set_enabled(self.image_ready)
-            self.command_button.set_visible(bool(Settings().custom_export_command.strip()))
+            self.share_button.set_visible(bool(Settings().custom_export_command.strip()))
 
 
     def _create_delete_screenshots_dialog(self) -> None:
@@ -453,11 +452,11 @@ class GradiaMainWindow(Adw.ApplicationWindow):
         if Settings().show_export_confirm_dialog:
             dialog = Adw.MessageDialog.new(
                 parent=self.get_root(),
-                heading=_("Confirm Upload Command"),
-                body=_("Are you sure you want to\n run the upload command?")
+                heading=_("Confirm Upload"),
+                body=_("Are you sure you want to upload this image?")
             )
             dialog.add_response("cancel", _("Cancel"))
-            dialog.add_response("confirm", _("Run"))
+            dialog.add_response("confirm", _("Upload"))
             dialog.set_default_response("cancel")
             dialog.set_size_request(350, -1)
             dialog.set_response_appearance("confirm", Adw.ResponseAppearance.SUGGESTED)


### PR DESCRIPTION
- tell user which provider they have currently selected in "Confirm Upload" dialog
- rename command button to share button
- add keyboard shortcut for sharing an image