### PR TITLE
README: make repology badge display 3 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you'd like Gradia to **open automatically** after taking a screenshot, you ca
 > [!WARNING]
 > These methods are not officially supported. Issues related to packaging in these methods should be reported outside this project's bug tracker.
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/gradia.svg)](https://repology.org/project/gradia/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/gradia.svg?columns=3)](https://repology.org/project/gradia/versions)
 
 ## How to build
 


### PR DESCRIPTION
As the list of repositories grow that support gradia the badge will stay a size that is manageable and flows better with the README proportions

Preview:  
<img width="814" height="328" alt="Screenshot_20250722_210008" src="https://github.com/user-attachments/assets/b7b255e6-a986-40c1-b41e-736488bbd753" />
