### PR TITLE
Annotation shortcuts

### DIFF
--- a/data/ui/image_sidebar.blp
+++ b/data/ui/image_sidebar.blp
@@ -35,7 +35,7 @@ template $GradiaImageSidebar : Adw.Bin {
     }
 
     content: Adw.PreferencesPage {
-      $GradiaDrawingToolsGroup annotation_tools_group {}
+      $GradiaDrawingToolsGroup drawing_tools_group {}
 
       Adw.PreferencesGroup background_selector_group {}
 

--- a/gradia/overlay/drawing_actions.py
+++ b/gradia/overlay/drawing_actions.py
@@ -31,6 +31,7 @@ logging = Logger()
 
 start_time_seed = int(time.time())
 
+
 class DrawingMode(Enum):
     SELECT = "SELECT"
     PEN = "PEN"
@@ -48,14 +49,31 @@ class DrawingMode(Enum):
             "PEN": _("Pen"),
             "ARROW": _("Arrow"),
             "LINE": _("Line"),
-            "SQUARE": _("Square"),
-            "CIRCLE": _("Circle"),
+            "SQUARE": _("Rectangle"),
+            "CIRCLE": _("Oval"),
             "TEXT": _("Text"),
             "SELECT": _("Select"),
             "HIGHLIGHTER": _("Highlighter"),
             "CENSOR": _("Censor"),
             "NUMBER": _("Number"),
         }[self.value]
+
+    @property
+    def shortcuts(self):
+        return DrawingMode._shortcuts[self]
+
+DrawingMode._shortcuts = {
+    DrawingMode.SELECT:       ["0", "KP_0", "grave", "s"],
+    DrawingMode.PEN:          ["1", "KP_1", "d", "p"],
+    DrawingMode.TEXT:         ["2", "KP_2", "t"],
+    DrawingMode.LINE:         ["3", "KP_3", "l"],
+    DrawingMode.ARROW:        ["4", "KP_4", "a"],
+    DrawingMode.SQUARE:       ["5", "KP_5", "r"],
+    DrawingMode.CIRCLE:       ["6", "KP_6", "o"],
+    DrawingMode.HIGHLIGHTER:  ["7", "KP_7", "h"],
+    DrawingMode.CENSOR:       ["8", "KP_8", "c"],
+    DrawingMode.NUMBER:       ["9", "KP_9", "n"],
+}
 
 
 class DrawingAction:

--- a/gradia/overlay/drawing_actions.py
+++ b/gradia/overlay/drawing_actions.py
@@ -32,13 +32,13 @@ logging = Logger()
 start_time_seed = int(time.time())
 
 class DrawingMode(Enum):
+    SELECT = "SELECT"
     PEN = "PEN"
-    ARROW = "ARROW"
+    TEXT = "TEXT"
     LINE = "LINE"
+    ARROW = "ARROW"
     SQUARE = "SQUARE"
     CIRCLE = "CIRCLE"
-    TEXT = "TEXT"
-    SELECT = "SELECT"
     HIGHLIGHTER = "HIGHLIGHTER"
     CENSOR = "CENSOR"
     NUMBER = "NUMBER"

--- a/gradia/ui/drawing_tools_group.py
+++ b/gradia/ui/drawing_tools_group.py
@@ -169,6 +169,10 @@ class DrawingToolsGroup(Adw.PreferencesGroup):
 
         self._activate_draw_mode_action(DrawingMode(self.settings.draw_mode))
 
+    def set_drawing_mode(self, mode: DrawingMode) -> None:
+        if mode in self.tool_buttons:
+            self.tool_buttons[mode].set_active(True)
+
     """
     Callbacks
     """

--- a/gradia/ui/image_sidebar.py
+++ b/gradia/ui/image_sidebar.py
@@ -40,7 +40,7 @@ PRESET_RATIOS_DICT = dict((v, l) for l, v in PRESET_RATIOS)
 class ImageSidebar(Adw.Bin):
     __gtype_name__ = "GradiaImageSidebar"
 
-    annotation_tools_group: DrawingToolsGroup = Gtk.Template.Child()
+    drawing_tools_group: DrawingToolsGroup = Gtk.Template.Child()
     background_selector_group: Adw.PreferencesGroup = Gtk.Template.Child()
     image_options_group = Gtk.Template.Child()
     disable_button: Gtk.Switch = Gtk.Template.Child()
@@ -274,3 +274,6 @@ class ImageSidebar(Adw.Bin):
 
     def _label_for_ratio_value(self, value: str) -> str:
         return PRESET_RATIOS_DICT.get(value, value if value else "Auto")
+
+    def set_drawing_mode(self, mode):
+        self.drawing_tools_group.set_drawing_mode(mode)

--- a/gradia/ui/ui_parts.py
+++ b/gradia/ui/ui_parts.py
@@ -96,7 +96,17 @@ class ShortcutsDialog:
                 "shortcuts": [
                     (_("Undo"), "<Ctrl>Z"),
                     (_("Redo"), "<Ctrl><Shift>Z"),
-                    (_("Erase Selected"), "Delete")
+                    (_("Erase Selected"), "Delete"),
+                    (_("Select"),      "0 S"),
+                    (_("Pen"),         "1 P"),
+                    (_("Text"),        "2 T"),
+                    (_("Line"),        "3 L"),
+                    (_("Arrow"),       "4 A"),
+                    (_("Rectangle"),   "5 R"),
+                    (_("Oval"),        "6 O"),
+                    (_("Highlighter"), "7 H"),
+                    (_("Censor"),      "8 C"),
+                    (_("Number"),      "9 N"),
                 ]
             },
             {

--- a/gradia/ui/window.py
+++ b/gradia/ui/window.py
@@ -132,15 +132,11 @@ class GradiaMainWindow(Adw.ApplicationWindow):
         self.create_action("zoom-out", lambda *_: self.image_bin.zoom_out(), ["<Control>minus", "<Control>KP_Subtract"])
         self.create_action("reset-zoom", lambda *_: self.image_bin.reset_zoom(), ["<Control>0", "<Control>KP_0"])
 
-        for i, mode in enumerate(DrawingMode): # Drawing actions accels 0-9
-            if i > 9:
-                break
-            key = f"set-drawing-mode-{i}"
-            accels = [str(i), f"KP_{i}"] + (["grave"] if i == 0 else [])
-            self.create_action(&é²12
-                key,
+        for mode in DrawingMode:
+            self.create_action(
+                f"set-drawing-mode-{mode.name.lower()}",
                 lambda *_, m=mode: self.sidebar.set_drawing_mode(m),
-                accels
+                mode.shortcuts
             )
 
         self.create_action("undo", lambda *_: self.drawing_overlay.undo(), ["<Primary>z"])

--- a/gradia/ui/window.py
+++ b/gradia/ui/window.py
@@ -132,6 +132,17 @@ class GradiaMainWindow(Adw.ApplicationWindow):
         self.create_action("zoom-out", lambda *_: self.image_bin.zoom_out(), ["<Control>minus", "<Control>KP_Subtract"])
         self.create_action("reset-zoom", lambda *_: self.image_bin.reset_zoom(), ["<Control>0", "<Control>KP_0"])
 
+        for i, mode in enumerate(DrawingMode): # Drawing actions accels 0-9
+            if i > 9:
+                break
+            key = f"set-drawing-mode-{i}"
+            accels = [str(i), f"KP_{i}"] + (["grave"] if i == 0 else [])
+            self.create_action(&é²12
+                key,
+                lambda *_, m=mode: self.sidebar.set_drawing_mode(m),
+                accels
+            )
+
         self.create_action("undo", lambda *_: self.drawing_overlay.undo(), ["<Primary>z"])
         self.create_action("redo", lambda *_: self.drawing_overlay.redo(), ["<Primary><Shift>z"])
         self.create_action("clear", lambda *_: self.drawing_overlay.clear_drawing())


### PR DESCRIPTION
These are the mappings. I renamed some drawing actions to make their names clearer and assigned each one a mnemonic shortcut using the first letter of its name and a number shortcut.

Closes #187 

<img width="588" height="588" alt="image" src="https://github.com/user-attachments/assets/828dd7a2-07ea-4a79-9030-394fe3569823" />
