### PR TITLE
Make side panels collapsible to reduce UI clutter

### DIFF
--- a/data/be.alexandervanhee.gradia.gschema.xml
+++ b/data/be.alexandervanhee.gradia.gschema.xml
@@ -94,6 +94,15 @@
       <summary>Whether to ask before running the export command.</summary>
     </key>
 
+    <key name="image-options-expanded" type="b">
+      <default>true</default>
+      <summary>Whether the Image Options panel is expanded.</summary>
+    </key>
+    <key name="file-info-expanded" type="b">
+      <default>true</default>
+      <summary>Whether the Current File panel is expanded.</summary>
+    </key>
+
     <key name="source-snippet-show-frame" type="b">
       <default>true</default>
       <summary>Whether to have a window frame for the source snippet.</summary>

--- a/data/ui/image_sidebar.blp
+++ b/data/ui/image_sidebar.blp
@@ -49,7 +49,8 @@ template $GradiaImageSidebar : Adw.Bin {
       Adw.PreferencesGroup background_selector_group {}
 
       Adw.PreferencesGroup image_options_group {
-        title: _("Image Options");
+        Adw.ExpanderRow image_options_expander {
+          title: _("Image Options");
 
         Adw.SpinRow padding_row {
           title: _("Padding");
@@ -129,11 +130,12 @@ template $GradiaImageSidebar : Adw.Bin {
             }
           }
         }
-
+        }
       }
 
       Adw.PreferencesGroup file_info_group {
-        title: _("Current File");
+        Adw.ExpanderRow file_info_expander {
+          title: _("Current File");
 
         Adw.ActionRow filename_row {
           title: _("Name");
@@ -164,6 +166,7 @@ template $GradiaImageSidebar : Adw.Bin {
           title: _("Modified image size");
           subtitle: _("N/A");
           styles ["property"]
+        }
         }
       }
       };

--- a/gradia/backend/settings.py
+++ b/gradia/backend/settings.py
@@ -299,6 +299,17 @@ class Settings:
         else:
             print(f"Warning: GSettings key '{key}' not found in schema.")
 
+    def bind_property(self, widget: object, prop: str, key: str) -> None:
+        if key in self._settings.list_keys():
+            self._settings.bind(
+                key,
+                widget,
+                prop,
+                Gio.SettingsBindFlags.DEFAULT
+            )
+        else:
+            print(f"Warning: GSettings key '{key}' not found in schema.")
+
     def bind_spin_row(self, spin_row: object, key: str) -> None:
         if key in self._settings.list_keys():
             self._settings.bind(

--- a/gradia/ui/image_sidebar.py
+++ b/gradia/ui/image_sidebar.py
@@ -44,6 +44,7 @@ class ImageSidebar(Adw.Bin):
     drawing_tools_group: DrawingToolsGroup = Gtk.Template.Child()
     background_selector_group: Adw.PreferencesGroup = Gtk.Template.Child()
     image_options_group = Gtk.Template.Child()
+    image_options_expander: Adw.ExpanderRow = Gtk.Template.Child()
     padding_row: Adw.SpinRow = Gtk.Template.Child()
     padding_adjustment: Gtk.Adjustment = Gtk.Template.Child()
     corner_radius_row: Adw.SpinRow = Gtk.Template.Child()
@@ -54,6 +55,7 @@ class ImageSidebar(Adw.Bin):
     filename_row: Adw.ActionRow = Gtk.Template.Child()
     location_row: Adw.ActionRow = Gtk.Template.Child()
     processed_size_row: Adw.ActionRow = Gtk.Template.Child()
+    file_info_expander: Adw.ExpanderRow = Gtk.Template.Child()
     share_button: Gtk.Button = Gtk.Template.Child()
     rotate_left_button: Gtk.Button = Gtk.Template.Child()
     rotate_right_button: Gtk.Button = Gtk.Template.Child()
@@ -72,7 +74,6 @@ class ImageSidebar(Adw.Bin):
         self._current_rotation = 0
         self._current_background = None
 
-        self.image_options_group_content = self.image_options_group.get_first_child().get_first_child().get_next_sibling()
         self.background_selector: BackgroundSelector = BackgroundSelector(
             callback=self._on_background_changed
         )
@@ -90,6 +91,8 @@ class ImageSidebar(Adw.Bin):
         self.auto_balance_toggle.set_active(self.settings.image_auto_balance)
         self.aspect_ratio_selector.set_ratio(self.settings.image_aspect_ratio)
         self._current_rotation = self.settings.image_rotation
+        self.settings.bind_property(self.image_options_expander, "expanded", "image-options-expanded")
+        self.settings.bind_property(self.file_info_expander, "expanded", "file-info-expanded")
 
     def _on_background_changed(self, updated_background: Background) -> None:
         self._current_background = updated_background


### PR DESCRIPTION
A last minor change: replacing the 2 less important side panels with their collapsible counterparts, and make the app remember the state to have a cleaner UI. 