### PR TITLE
Allow annotation options to be changed in select mode

### DIFF
--- a/gradia/backend/tool_config.py
+++ b/gradia/backend/tool_config.py
@@ -32,6 +32,7 @@ class ToolOption:
         border_color: Gdk.RGBA = None,
         font: str = None,
         on_change_callback: Optional[Callable[['ToolOption'], None]] = None,
+        is_temporary: bool = False,
     ) -> None:
         self.mode = mode
         self._size = size
@@ -40,6 +41,7 @@ class ToolOption:
         self._border_color_str = self._rgba_to_str(border_color or Gdk.RGBA(0,0,0,0))
         self._font = font or "Adwaita Sans"
         self._on_change_callback = on_change_callback
+        self._is_temporary = is_temporary
 
     def _rgba_to_str(self, rgba: Gdk.RGBA) -> str:
         return f"rgba({rgba.red:.2f}, {rgba.green:.2f}, {rgba.blue:.2f}, {rgba.alpha:.2f})"
@@ -52,7 +54,7 @@ class ToolOption:
         return Gdk.RGBA(r, g, b, a)
 
     def _notify_change(self):
-        if self._on_change_callback:
+        if self._on_change_callback and not self._is_temporary:
             self._on_change_callback(self)
 
     @property
@@ -138,7 +140,7 @@ class ToolOption:
             on_change_callback=on_change_callback,
         )
 
-    def copy(self) -> "ToolOption":
+    def copy(self, is_temporary: bool = False) -> "ToolOption":
         return ToolOption(
             mode=self.mode,
             size=self.size,
@@ -146,7 +148,8 @@ class ToolOption:
             fill_color=self.fill_color,
             border_color=self.border_color,
             font=self.font,
-            on_change_callback=self._on_change_callback,
+            on_change_callback=self._on_change_callback if not is_temporary else None,
+            is_temporary=is_temporary,
         )
 
     def update_without_notify(self, **kwargs):
@@ -357,5 +360,3 @@ class ToolConfig:
                 secondary_color_list=ToolConfig.TEXT_BACKGROUND_COLORS
             ),
         ]
-
-

--- a/gradia/overlay/drawing_overlay.py
+++ b/gradia/overlay/drawing_overlay.py
@@ -16,7 +16,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import cairo
-from gi.repository import Adw, Gdk, Gio, Gtk
+from gi.repository import Adw, Gdk, Gio, Gtk, GObject
 from typing import Tuple
 from enum import Enum
 
@@ -53,6 +53,10 @@ class ResizeHandle(Enum):
 
 class DrawingOverlay(Gtk.DrawingArea):
     __gtype_name__ = "GradiaDrawingOverlay"
+
+    __gsignals__ = {
+        'selection-changed': (GObject.SignalFlags.RUN_FIRST, None, (object,))
+    }
 
     def __init__(self, **kwargs):
         super().__init__(can_focus=True, **kwargs)
@@ -107,6 +111,7 @@ class DrawingOverlay(Gtk.DrawingArea):
     def selected_action(self, action: DrawingAction | None) -> None:
         self._selected_action = action
         self.erase_selected_revealer.set_reveal_child(action is not None)
+        self.emit('selection-changed', action.options if action else None)
 
     def _can_resize_action(self, action: DrawingAction) -> bool:
         return isinstance(action, (RectAction, CircleAction, CensorAction, ArrowAction, LineAction))

--- a/gradia/ui/widget/drawing_tools_grid.py
+++ b/gradia/ui/widget/drawing_tools_grid.py
@@ -107,3 +107,11 @@ class DrawingToolsGrid(Gtk.Grid):
 
     def set_current_tool(self, mode: DrawingMode):
         self._select_tool(mode)
+
+    def set_secondary_highlight_tool(self, mode: Optional[DrawingMode]):
+        for button in self._buttons.values():
+            button.add_css_class("flat")
+            button.remove_css_class("accent")
+        if mode and mode in self._buttons:
+            self._buttons[mode].remove_css_class("flat")
+            self._buttons[mode].add_css_class("accent")


### PR DESCRIPTION
Users can now edit annotation properties after placement using the selection tool. When an annotation is selected, its properties (colour, size etc ) can be modified through the tool panel . These temporary changes only affect the selected annotation and do not change the default settings for that annotation type.

<img width="1097" height="797" alt="image" src="https://github.com/user-attachments/assets/4d78cc99-42bc-4b14-8250-45b27bb811c4" />

Closes #189 