### PR TITLE
Disable the Undo/Redo buttons when there is nothing to undo/redo

### DIFF
--- a/gradia/ui/window.py
+++ b/gradia/ui/window.py
@@ -157,8 +157,8 @@ class GradiaMainWindow(Adw.ApplicationWindow):
                 disable_on_entry_focus=True
             )
 
-        self.create_action("undo", lambda *_: self.drawing_overlay.undo(), ["<Primary>z"])
-        self.create_action("redo", lambda *_: self.drawing_overlay.redo(), ["<Primary><Shift>z"])
+        self.create_action("undo", lambda *_: self.drawing_overlay.undo(), ["<Primary>z"], enabled=False)
+        self.create_action("redo", lambda *_: self.drawing_overlay.redo(), ["<Primary><Shift>z"], enabled=False)
         self.create_action("clear", lambda *_: self.drawing_overlay.clear_drawing())
         self.create_action("draw-mode", lambda action, param: self.drawing_overlay.set_drawing_mode(DrawingMode(param.get_string())), vt="s")
 
@@ -178,6 +178,7 @@ class GradiaMainWindow(Adw.ApplicationWindow):
         self.image_stack = self.image_bin.stack
         self.picture = self.image_bin.picture
         self.drawing_overlay = self.image_bin.drawing_overlay
+        self.drawing_overlay._update_undo_redo_action_states()
         self.breakpoint.add_setter(self.image_bin, "compact", True)
 
     def _setup_sidebar(self) -> None:


### PR DESCRIPTION
The undo button is now disabled by default. When an action is added to the undo list, the button is enabled. When the list becomes empty after an action, the button becomes disabled. The same is true with the redo button and the redo list.