### PR TITLE
Fix: Set visible cursor for shape tools

### DIFF
--- a/gradia/overlay/drawing_overlay.py
+++ b/gradia/overlay/drawing_overlay.py
@@ -722,17 +722,7 @@ class DrawingOverlay(Gtk.DrawingArea):
 
         else:
             if self._is_point_in_image(x_widget, y_widget):
-                if self.options.mode in [
-                    DrawingMode.PEN,
-                    DrawingMode.HIGHLIGHTER,
-                    DrawingMode.SQUARE,
-                    DrawingMode.CIRCLE,
-                    DrawingMode.ARROW,
-                    DrawingMode.LINE,
-                ]:
-                    name = "crosshair"
-                else:
-                    name = "cell"
+                name = "crosshair"
             else:
                 name = "default"
 


### PR DESCRIPTION
The mouse cursor was invisible for shape drawing tools (Rectangle, Oval, Arrow, Line). This was due to requesting a non-standard cell cursor name, which is often missing from cursor themes.

This commit changes the cursor for these tools to crosshair. This ensures the cursor is always visible and provides a standard, intuitive pointer for precision drawing, making the tools usable.

This resolves #238 for me :slightly_smiling_face: 