### PR TITLE
Fix compatibility with pygobject-3.50

### DIFF
--- a/gradia/backend/tool_config.py
+++ b/gradia/backend/tool_config.py
@@ -21,6 +21,7 @@ from gradia.overlay.drawing_actions import DrawingMode
 import re
 import json
 from gradia.backend.settings import Settings
+from gradia.utils.colors import make_rgba, tuple_to_rgba
 
 class ToolOption:
     def __init__(
@@ -36,9 +37,14 @@ class ToolOption:
     ) -> None:
         self.mode = mode
         self._size = size
-        self._primary_color_str = self._rgba_to_str(primary_color or Gdk.RGBA(0,0,0,1))
-        self._fill_color_str = self._rgba_to_str(fill_color or Gdk.RGBA(1,1,1,1))
-        self._border_color_str = self._rgba_to_str(border_color or Gdk.RGBA(0,0,0,0))
+
+        default_primary = make_rgba(0.0, 0.0, 0.0, 1.0)
+        default_fill = make_rgba(1.0, 1.0, 1.0, 1.0)
+        default_border = make_rgba(0.0, 0.0, 0.0, 0.0)
+
+        self._primary_color_str = self._rgba_to_str(primary_color or default_primary)
+        self._fill_color_str = self._rgba_to_str(fill_color or default_fill)
+        self._border_color_str = self._rgba_to_str(border_color or default_border)
         self._font = font or "Adwaita Sans"
         self._on_change_callback = on_change_callback
         self._is_temporary = is_temporary
@@ -51,7 +57,7 @@ class ToolOption:
         if not m:
             return Gdk.RGBA(0,0,0,1)
         r, g, b, a = map(float, m.groups())
-        return Gdk.RGBA(r, g, b, a)
+        return make_rgba(r, g, b, a)
 
     def _notify_change(self):
         if self._on_change_callback and not self._is_temporary:
@@ -123,11 +129,6 @@ class ToolOption:
 
     @classmethod
     def deserialize(cls, json_str: str, on_change_callback: Optional[Callable[['ToolOption'], None]] = None) -> "ToolOption":
-        def tuple_to_rgba(t):
-            if not t or len(t) != 4:
-                return Gdk.RGBA(0, 0, 0, 1)
-            return Gdk.RGBA(t[0], t[1], t[2], t[3])
-
         data = json.loads(json_str)
         mode = DrawingMode[data.get("mode", "PEN")]
         return cls(
@@ -211,22 +212,22 @@ class ToolOptionsManager:
 class ToolConfig:
 
     TEXT_COLORS = [
-        (Gdk.RGBA(0.65,0.11,0.18, 1), _("Red")),
-        (Gdk.RGBA(0.15,0.64,0.41, 1), _("Green")),
-        (Gdk.RGBA(0.1,0.37,0.71, 1), _("Blue")),
-        (Gdk.RGBA(0.9,0.65,0.04, 1), _("Yellow")),
-        (Gdk.RGBA(0,0,0, 1), _("Black")),
-        (Gdk.RGBA(1.0, 1.0, 1.0, 1), _("White")),
+        (make_rgba(0.65, 0.11, 0.18, 1.0), _("Red")),
+        (make_rgba(0.15, 0.64, 0.41, 1.0), _("Green")),
+        (make_rgba(0.10, 0.37, 0.71, 1.0), _("Blue")),
+        (make_rgba(0.90, 0.65, 0.04, 1.0), _("Yellow")),
+        (make_rgba(0.00, 0.00, 0.00, 1.0), _("Black")),
+        (make_rgba(1.00, 1.00, 1.00, 1.0), _("White")),
     ]
 
     TEXT_BACKGROUND_COLORS = [
-        (Gdk.RGBA(0.96,0.38,0.32, 1), _("Red")),
-        (Gdk.RGBA(0.56,0.94,0.64, 1), _("Green")),
-        (Gdk.RGBA(0.6,0.76,0.95, 1), _("Blue")),
-        (Gdk.RGBA(0.98,0.94,0.42, 1), _("Yellow")),
-        (Gdk.RGBA(1.0, 1.0, 1.0, 1), _("White")),
-        (Gdk.RGBA(0,0,0, 1), _("Black")),
-        (Gdk.RGBA(0, 0, 0, 0), _("Transparent"))
+        (make_rgba(0.96, 0.38, 0.32, 1.0), _("Red")),
+        (make_rgba(0.56, 0.94, 0.64, 1.0), _("Green")),
+        (make_rgba(0.60, 0.76, 0.95, 1.0), _("Blue")),
+        (make_rgba(0.98, 0.94, 0.42, 1.0), _("Yellow")),
+        (make_rgba(1.00, 1.00, 1.00, 1.0), _("White")),
+        (make_rgba(0.00, 0.00, 0.00, 1.0), _("Black")),
+        (make_rgba(0.00, 0.00, 0.00, 0.0), _("Transparent"))
     ]
 
     def __init__(
@@ -256,10 +257,6 @@ class ToolConfig:
 
     @staticmethod
     def get_all_tools_positions():
-        black = Gdk.RGBA(red=0, green=0, blue=0, alpha=1)
-        white = Gdk.RGBA(red=1, green=1, blue=1, alpha=1)
-        transparent = Gdk.RGBA(red=0, green=0, blue=0, alpha=0)
-
         return [
             ToolConfig(
                 mode=DrawingMode.SELECT,
@@ -331,12 +328,12 @@ class ToolConfig:
                 has_scale=True,
                 has_primary_color=True,
                 primary_color_list=[
-                        (Gdk.RGBA(0.88, 0.11, 0.14, 0.4), _("Red")),
-                        (Gdk.RGBA(0.18, 0.76, 0.49, 0.4), _("Green")),
-                        (Gdk.RGBA(0.21, 0.52, 0.89, 0.4), _("Blue")),
-                        (Gdk.RGBA(0.96, 0.83, 0.18, 0.4), _("Yellow")),
-                        (Gdk.RGBA(0.51, 0.24, 0.61, 0.4), _("Purple")),
-                        (Gdk.RGBA(1.0, 1.0, 1.0, 0.4), _("White")),
+                        (make_rgba(0.88, 0.11, 0.14, 0.4), _("Red")),
+                        (make_rgba(0.18, 0.76, 0.49, 0.4), _("Green")),
+                        (make_rgba(0.21, 0.52, 0.89, 0.4), _("Blue")),
+                        (make_rgba(0.96, 0.83, 0.18, 0.4), _("Yellow")),
+                        (make_rgba(0.51, 0.24, 0.61, 0.4), _("Purple")),
+                        (make_rgba(1.0, 1.0, 1.0, 0.4), _("White")),
                     ]
             ),
             ToolConfig(

--- a/gradia/overlay/drawing_overlay.py
+++ b/gradia/overlay/drawing_overlay.py
@@ -371,7 +371,7 @@ class DrawingOverlay(Gtk.DrawingArea):
         points = bounds.get_points()
         widget_points = [self._image_to_widget_coords(int(p[0]), int(p[1])) for p in points]
         accent = Adw.StyleManager.get_default().get_accent_color_rgba()
-        cr.set_source_rgba(*accent)
+        cr.set_source_rgba(accent.red, accent.green, accent.blue, accent.alpha)
         cr.set_line_width(2)
         cr.move_to(*widget_points[0])
         for point in widget_points[1:]:
@@ -384,7 +384,7 @@ class DrawingOverlay(Gtk.DrawingArea):
                 cr.set_source_rgba(1.0, 1.0, 1.0, 1.0)
                 cr.rectangle(handle_x, handle_y, HANDLE_SIZE, HANDLE_SIZE)
                 cr.fill()
-                cr.set_source_rgba(*accent)
+                cr.set_source_rgba(accent.red, accent.green, accent.blue, accent.alpha)
                 cr.rectangle(handle_x, handle_y, HANDLE_SIZE, HANDLE_SIZE)
                 cr.stroke()
 
@@ -769,7 +769,12 @@ class DrawingOverlay(Gtk.DrawingArea):
             action.draw(cr, self._image_to_widget_coords, scale)
 
         if self.is_drawing and self.options.mode != DrawingMode.TEXT and self.options.mode != DrawingMode.NUMBER:
-            cr.set_source_rgba(*self.options.primary_color)
+            cr.set_source_rgba(
+                self.options.primary_color.red,
+                self.options.primary_color.green,
+                self.options.primary_color.blue,
+                self.options.primary_color.alpha,
+            )
             if self.options.mode == DrawingMode.PEN and len(self.current_stroke) > 1:
                 StrokeAction(self.current_stroke, self.options.copy()).draw(cr, self._image_to_widget_coords, scale)
             elif self.options.mode == DrawingMode.HIGHLIGHTER and len(self.current_stroke) > 1:

--- a/gradia/ui/widget/quick_color_picker.py
+++ b/gradia/ui/widget/quick_color_picker.py
@@ -16,22 +16,22 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from gi.repository import Gtk, Adw, Gdk, GObject, Gio
-from gradia.utils.colors import is_light_color_rgba, rgba_to_hex
+from gradia.utils.colors import is_light_color_rgba, rgba_to_hex, make_rgba
+
 
 class ColorPickerMixin:
     def _get_base_colors(self, alpha=1.0, secondary=False):
         base_colors = [
-            (Gdk.RGBA(0.88, 0.11, 0.14, alpha), _("Red")),
-            (Gdk.RGBA(0.18, 0.76, 0.49, alpha), _("Green")),
-            (Gdk.RGBA(0.21, 0.52, 0.89, alpha), _("Blue")),
-            (Gdk.RGBA(0.96, 0.83, 0.18, alpha), _("Yellow")),
-            (Gdk.RGBA(0.0, 0.0, 0.0, alpha), _("Black")),
-            (Gdk.RGBA(1.0, 1.0, 1.0, alpha), _("White")),
-            ]
+            (make_rgba(0.88, 0.11, 0.14, alpha), _("Red")),
+            (make_rgba(0.18, 0.76, 0.49, alpha), _("Green")),
+            (make_rgba(0.21, 0.52, 0.89, alpha), _("Blue")),
+            (make_rgba(0.96, 0.83, 0.18, alpha), _("Yellow")),
+            (make_rgba(0.0, 0.0, 0.0, alpha), _("Black")),
+            (make_rgba(1.0, 1.0, 1.0, alpha), _("White")),
+        ]
 
         if secondary:
-            base_colors.append((Gdk.RGBA(0, 0, 0, 0), _("Transparent")))
-
+            base_colors.append((make_rgba(0.0, 0.0, 0.0, 0.0), _("Transparent")))
 
         return base_colors
 

--- a/gradia/utils/colors.py
+++ b/gradia/utils/colors.py
@@ -20,6 +20,19 @@ from gi.repository import Gdk
 HexColor = str
 RGBTuple = tuple[int, int, int]
 
+def make_rgba(r: float, g: float, b: float, a: float) -> Gdk.RGBA:
+    """Utility to construct a Gdk.RGBA with the given components.
+
+    Gdk.RGBA does not take RGBA values as constructor arguments; you must
+    instantiate it and then assign the channels explicitly.
+    """
+    rgba = Gdk.RGBA()
+    rgba.red = r
+    rgba.green = g
+    rgba.blue = b
+    rgba.alpha = a
+    return rgba
+
 def hex_to_rgba(hex_color: HexColor, alpha: float | None = None) -> Gdk.RGBA:
     """
     Converts hexadecimal color code to `Gdk.RGBA` object.
@@ -57,6 +70,23 @@ def hex_to_rgb(hex_color: HexColor) -> RGBTuple:
     hex_color = hex_color.lstrip('#')
     r, g, b = (int(hex_color[i:i+2], 16) for i in (0, 2, 4))
     return (r, g, b)
+
+def rgba_to_tuple(color: Gdk.RGBA) -> tuple[float, float, float, float]:
+    return (color.red, color.green, color.blue, color.alpha)
+
+def tuple_to_rgba(color: tuple[float, float, float, float] | None) -> Gdk.RGBA:
+    rgba = Gdk.RGBA()
+    if not color or len(color) != 4:
+        rgba.red = 0.0
+        rgba.green = 0.0
+        rgba.blue = 0.0
+        rgba.alpha = 1.0
+        return rgba
+    rgba.red = float(color[0])
+    rgba.green = float(color[1])
+    rgba.blue = float(color[2])
+    rgba.alpha = float(color[3])
+    return rgba
 
 def has_visible_color(color):
     return any(c > 0 for c in color[:3]) or (len(color) > 3 and color[3] > 0)


### PR DESCRIPTION
Gdk.RGBA constructor now ignores parameters:
```
>>> Gdk.RGBA(1,1,1,1)
<stdin-1>:1: DeprecationWarning: Passing arguments to gi.types.Boxed.__init__() is deprecated. All arguments passed will be ignored.
```

Note, that I only tested in a single setup, which looks like this:
* glib-2.84.4
* pygobject-3.50.1
* gtk-4.20.3
* libadwaita-1.8.2
* gtksourceview-5.16.0

Nevertheless, this change should be useful, if not now, then maybe later.

Closes #256