### PR TITLE
feat: Add --screenshot=GRAB option for direct area capture

### DIFF
--- a/build-aux/flatpak/be.alexandervanhee.gradia.json
+++ b/build-aux/flatpak/be.alexandervanhee.gradia.json
@@ -10,7 +10,8 @@
     "--device=dri",
     "--socket=wayland",
     "--filesystem=xdg-pictures",
-    "--share=network"
+    "--share=network",
+    "--talk-name=org.freedesktop.Flatpak"
   ],
   "build-options": {
     "strip": true

--- a/data/help.txt
+++ b/data/help.txt
@@ -8,6 +8,7 @@ Options:
                                 MODE can be:
                                   INTERACTIVE (default) - Interactive screenshot
                                   FULL - Full screen screenshot
+                                  GRAB - Direct area selection (no dialog)
   --delay=MILLISECONDS          Delay before taking screenshot (in milliseconds)
 
 Arguments:
@@ -18,6 +19,7 @@ Examples:
   gradia image.png             Open image.png in Gradia
   gradia --screenshot          Take an interactive screenshot
   gradia --screenshot=FULL     Take a full screen screenshot
+  gradia --screenshot=GRAB     Select an area to screenshot
   gradia --screenshot --delay=3000   Take screenshot after 3 second delay
   gradia --screenshot=FULL --delay=1500   Take full screenshot after 1.5 second delay
   cat image.png | gradia       Open image from standard input (stdin)

--- a/gradia/gradia.in
+++ b/gradia/gradia.in
@@ -87,8 +87,82 @@ if __name__ == '__main__':
                 except ValueError:
                     print("Invalid delay value. Using default of 0.")
                     delay = 0
-    if mode in ('INTERACTIVE', 'FULL'):
-        flags = Xdp.ScreenshotFlags.INTERACTIVE if mode == 'INTERACTIVE' else Xdp.ScreenshotFlags.NONE
+    if mode == 'GRAB':
+        # GRAB mode: Use gnome-screenshot -a for direct area selection (no dialog)
+        import subprocess
+        import tempfile
+        from pathlib import Path
+        
+        # Check if running in Flatpak
+        is_flatpak = os.getenv('FLATPAK_ID') or Path('/.flatpak-info').exists()
+        
+        # Create temp file in a location accessible from both sandbox and host
+        if is_flatpak:
+            # Use XDG_PICTURES_DIR or home Pictures folder for host accessibility
+            pictures_dir = GLib.get_user_special_dir(GLib.USER_DIRECTORY_PICTURES)
+            if not pictures_dir:
+                pictures_dir = os.path.expanduser("~/Pictures")
+            os.makedirs(pictures_dir, exist_ok=True)
+            temp_path = os.path.join(pictures_dir, f".gradia_grab_{os.getpid()}.png")
+        else:
+            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
+                temp_path = tmp.name
+        
+        if delay > 0:
+            import time
+            time.sleep(delay / 1000)
+        
+        try:
+            if is_flatpak:
+                # Use flatpak-spawn to run gnome-screenshot on the host
+                result = subprocess.run(
+                    ['flatpak-spawn', '--host', 'gnome-screenshot', '-a', '-f', temp_path],
+                    capture_output=True,
+                    text=True
+                )
+            else:
+                # Run gnome-screenshot directly
+                result = subprocess.run(
+                    ['gnome-screenshot', '-a', '-f', temp_path],
+                    capture_output=True,
+                    text=True
+                )
+            
+            # Wait for file to appear (host filesystem -> sandbox sync may take a moment)
+            import time
+            max_wait = 3  # seconds
+            waited = 0
+            while waited < max_wait:
+                if os.path.exists(temp_path) and os.path.getsize(temp_path) > 0:
+                    break
+                time.sleep(0.1)
+                waited += 0.1
+            
+            if os.path.exists(temp_path) and os.path.getsize(temp_path) > 0:
+                screenshot_path = temp_path
+            else:
+                # gnome-screenshot failed or was cancelled
+                if os.path.exists(temp_path):
+                    os.unlink(temp_path)
+                print("Screenshot was cancelled or failed. Exiting.")
+                sys.exit(1)
+        except FileNotFoundError:
+            # gnome-screenshot not available, fall back to portal
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+            print("gnome-screenshot not found, falling back to portal dialog...")
+            screenshotter = QuickStartScreenshotTaker()
+            screenshot_path = screenshotter.take_screenshot(flags=Xdp.ScreenshotFlags.INTERACTIVE, delay_ms=0)
+            if screenshot_path is None:
+                print("Screenshot was cancelled or failed. Exiting.")
+                sys.exit(1)
+        
+        sys.argv.append(f"--screenshot-file={screenshot_path}")
+    elif mode in ('INTERACTIVE', 'FULL'):
+        if mode == 'FULL':
+            flags = Xdp.ScreenshotFlags.NONE
+        else:
+            flags = Xdp.ScreenshotFlags.INTERACTIVE
         screenshotter = QuickStartScreenshotTaker()
         screenshot_path = screenshotter.take_screenshot(flags=flags, delay_ms=delay)
         if screenshot_path is None:

--- a/gradia/main.py
+++ b/gradia/main.py
@@ -126,7 +126,7 @@ class GradiaApp(Adw.Application):
             file_path=file_path,
             start_screenshot=start_screenshot
         )
-        window.show()
+        window.present()
 
     def on_shutdown(self, application):
         logging.info("Application shutdown started, cleaning temp directories…")


### PR DESCRIPTION
## Summary

This PR adds a new `GRAB` mode to the `--screenshot` command-line option, enabling users to skip the screenshot portal dialog and go directly to area selection.

## Motivation
When setting up keyboard shortcuts for quick screenshot capture, users want to jump straight into selecting an area without navigating through the GNOME screenshot portal dialog. The existing `INTERACTIVE` mode shows a dialog where users must manually choose "Select area to grab," which adds friction to the workflow.

## Implementation

The `GRAB` mode uses `gnome-screenshot -a` via `flatpak-spawn --host` to invoke the host's native screenshot tool directly. This approach:
- Provides immediate crosshair cursor for area selection
- Bypasses the portal dialog entirely  
- Falls back gracefully to the portal dialog if `gnome-screenshot` is unavailable
- Handles host-to-sandbox filesystem synchronization with a retry mechanism

## Changes

| File | Description |
|------|-------------|
| [gradia/gradia.in](cci:7://file:///home/wada5103/repos/Gradia/gradia/gradia.in:0:0-0:0) | Implement GRAB mode with host command execution |
| [gradia/main.py](cci:7://file:///home/wada5103/repos/Gradia/gradia/main.py:0:0-0:0) | Use `window.present()` for proper window focus |
| [data/help.txt](cci:7://file:///home/wada5103/repos/Gradia/data/help.txt:0:0-0:0) | Document the new GRAB mode |
| `build-aux/flatpak/...json` | Add `org.freedesktop.Flatpak` permission |

## Usage

```bash
flatpak run be.alexandervanhee.gradia --screenshot=GRAB