### PR TITLE
Add option to close window after copying to clipboard

### DIFF
--- a/data/be.alexandervanhee.gradia.gschema.xml
+++ b/data/be.alexandervanhee.gradia.gschema.xml
@@ -76,6 +76,10 @@
       <default>false</default>
       <summary>Overwrite currently opened screenshot on close</summary>
     </key>
+    <key name="close-after-copy" type="b">
+      <default>false</default>
+      <summary>Close the window automatically after copying the image to the clipboard</summary>
+    </key>
     <key name="custom-export-command" type="s">
       <default>''</default>
       <summary>Custom command to run when pressing its button</summary>

--- a/data/ui/preferences_window.blp
+++ b/data/ui/preferences_window.blp
@@ -73,6 +73,14 @@ template $GradiaPreferencesWindow: Adw.PreferencesDialog {
         activatable: true;
       }
 
+      Adw.SwitchRow close_after_copy_switch {
+        title: _("_Close After Copying");
+        use-underline: true;
+        subtitle: _("Exit the app once the image is on the clipboard");
+        tooltip-text: _("Close the window after copying the image to the clipboard");
+        activatable: true;
+      }
+
       Adw.SwitchRow delete_screenshot_switch {
         title: _("_Trash Screenshots on Close");
         use-underline: true;

--- a/gradia/backend/settings.py
+++ b/gradia/backend/settings.py
@@ -105,6 +105,10 @@ class Settings:
         return self._settings.get_boolean("overwrite-screenshot")
 
     @property
+    def close_after_copy(self) -> bool:
+        return self._settings.get_boolean("close-after-copy")
+
+    @property
     def custom_export_command(self) -> str:
         return self._settings.get_string("custom-export-command")
 

--- a/gradia/ui/image_exporters.py
+++ b/gradia/ui/image_exporters.py
@@ -293,6 +293,8 @@ class ClipboardExporter(BaseImageExporter):
                     if not silent:
                         self.window.show_close_confirmation = False
                         self.window._show_notification(_("Image Copied"))
+                        if self.window.settings.close_after_copy and self.window.settings.exit_method != "copy":
+                            self.window.close()
 
                 except Exception as e:
                     self.window._show_notification(_("Failed to copy image to clipboard"))

--- a/gradia/ui/preferences/preferences_window.py
+++ b/gradia/ui/preferences/preferences_window.py
@@ -39,6 +39,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
     save_format_group: Adw.PreferencesGroup = Gtk.Template.Child()
     delete_screenshot_switch: Adw.SwitchRow = Gtk.Template.Child()
     overwrite_screenshot_switch: Adw.SwitchRow = Gtk.Template.Child()
+    close_after_copy_switch: Adw.SwitchRow = Gtk.Template.Child()
     confirm_upload_switch: Adw.SwitchRow = Gtk.Template.Child()
     save_format_combo: Adw.ComboRow = Gtk.Template.Child()
     provider_name: Gtk.Label = Gtk.Template.Child()
@@ -161,6 +162,7 @@ class PreferencesWindow(Adw.PreferencesDialog):
         self.settings.bind_switch(self.delete_screenshot_switch,"trash-screenshots-on-close")
         self.settings.bind_switch(self.confirm_upload_switch,"show-export-confirm-dialog")
         self.settings.bind_switch(self.overwrite_screenshot_switch,"overwrite-screenshot")
+        self.settings.bind_switch(self.close_after_copy_switch,"close-after-copy")
 
     @Gtk.Template.Callback()
     def on_choose_provider_clicked(self, button: Gtk.Button) -> None:


### PR DESCRIPTION
Closes #250.

Adds an opt-in **Close After Copying** preference under *Preferences → Closing*.

When enabled, the window closes automatically after a successful Ctrl+C copy. Default is **off**, so existing behavior is unchanged for current users.

## Behavior
- The close goes through the standard `_on_close_request` pipeline, so `overwrite-screenshot` and `trash-screenshots-on-close` still apply.
- The existing 1000 ms `delayed_destroy` in `_on_close_finished` continues to gate destruction so the Wayland clipboard transfer completes for large images.
- Skipped when `exit-method == "copy"` (i.e., "Copy and Close" already selected) to avoid a redundant full pixbuf re-render and a second clipboard write.
- The implicit post-processing copy (`copy_after_processing` in `set_image`, `silent=True`) is unaffected.