### PR TITLE
Fix rotate buttons rotating in the wrong direction

### DIFF
--- a/gradia/graphics/image_processor.py
+++ b/gradia/graphics/image_processor.py
@@ -128,11 +128,11 @@ class ImageProcessor:
         if self.rotation == 0:
             return image
         elif self.rotation == 90:
-            return image.transpose(Image.ROTATE_90)
+            return image.transpose(Image.ROTATE_270)
         elif self.rotation == 180:
             return image.transpose(Image.ROTATE_180)
         elif self.rotation == 270:
-            return image.transpose(Image.ROTATE_270)
+            return image.transpose(Image.ROTATE_90)
         else:
             return image
 


### PR DESCRIPTION
## Summary
- The rotate-right and rotate-left toolbar buttons rotated the image in the opposite direction of what the icon/button implies.
- `ImageSidebar` increments `rotation` by `+90` on rotate-right (clockwise intent) and `-90` on rotate-left (counter-clockwise intent).
- `ImageProcessor._apply_rotation` mapped `rotation == 90` to `Image.ROTATE_90`, but Pillow's `ROTATE_90` transpose is counter-clockwise, and `ROTATE_270` is clockwise — so the two cases were swapped, making both buttons rotate opposite to their intent.
- Swapped the `ROTATE_90`/`ROTATE_270` cases so rotate-right now rotates clockwise and rotate-left rotates counter-clockwise.

## Test plan
- [x] Verified with a quick Pillow script that `ROTATE_90` moves a marked top-left pixel to the bottom-left (counter-clockwise), confirming the mapping was inverted.
- [ ] Manually rotate an image left/right in Gradia and confirm it now matches the button direction.