### PR TITLE
Substitute prefix for tesseract paths

### DIFF
--- a/gradia/backend/ocr.py
+++ b/gradia/backend/ocr.py
@@ -45,7 +45,7 @@ class OCR:
     def __init__(self, window=None):
         self.tesseract_cmd = ocr_tesseract_cmd
         self.original_tessdata_dir = ocr_original_tessdata
-        self.user_tessdata_dir = os.path.expanduser(f"~/.var/app/{app_id}/data/tessdata")
+        self.user_tessdata_dir = os.path.join(GLib.get_user_data_dir(), "tessdata")
         self.window = window
 
         pytesseract.pytesseract.tesseract_cmd = self.tesseract_cmd

--- a/meson.build
+++ b/meson.build
@@ -62,8 +62,8 @@ else
 endif
 
 # OCR Directories
-OCR_TESSERACT_CMD = '/app/bin/tesseract'
-OCR_ORIGINAL_TESSDATA_DIR = '/app/share/tessdata'
+OCR_TESSERACT_CMD = join_paths(get_option('prefix'), 'bin', 'tesseract')
+OCR_ORIGINAL_TESSDATA_DIR = join_paths(get_option('prefix'), 'share', 'tessdata')
 
 enable_ocr = get_option('enable-ocr')
 


### PR DESCRIPTION
Instead of hardcoding `/app`, substitute with the configured prefix during build. Also substitute the user data dir.